### PR TITLE
feat(users): 新增帳號刪除功能及相關邏輯

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -355,9 +355,9 @@ export class AuthService {
     }
   }
 
-  generateTokens(userId: number) {
+  generateTokens(userId: number, roleLevel?: number) {
     const jti = uuidv4(); // 使用現有的 uuidv4
-    const payload = { sub: userId, jti };
+    const payload = { sub: userId, jti, role: roleLevel || 1 };
 
     const accessToken = this.jwtService.sign(payload, {
       secret: this.configService.get('JWT_SECRET'),
@@ -497,7 +497,7 @@ export class AuthService {
 
     // 生成 JWT Token 並返回
     // Generate JWT Token and return
-    return this.generateTokens(user.id);
+    return this.generateTokens(user.id, user.roleLevel);
   }
 
   /**
@@ -585,7 +585,7 @@ export class AuthService {
 
     // 產生 JWT token
     // Generate JWT token
-    return this.generateTokens(user.id);
+    return this.generateTokens(user.id, user.roleLevel);
   }
 
   /**
@@ -648,7 +648,7 @@ export class AuthService {
 
       // 產生 JWT token
       // Generate JWT token
-      return this.generateTokens(user.id);
+      return this.generateTokens(user.id, user.roleLevel);
 
     } catch (error) {
       console.error('Apple 登入錯誤:', error); // 記錄錯誤訊息
@@ -687,7 +687,7 @@ export class AuthService {
   
       // 產生 JWT token
       // Generate JWT token
-      return this.generateTokens(user.id);
+      return this.generateTokens(user.id, user.roleLevel);
     } catch (err) {
       throw new UnauthorizedException('WeChat token 驗證失敗');
     }
@@ -709,6 +709,6 @@ export class AuthService {
     if (!valid) throw new UnauthorizedException('密碼錯誤');
     // 產生 JWT token
     // Generate JWT token
-    return this.generateTokens(user.id);
+    return this.generateTokens(user.id, user.roleLevel);
   }
 }

--- a/src/auth/strategy/jwt.strategy.ts
+++ b/src/auth/strategy/jwt.strategy.ts
@@ -46,6 +46,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
     return {
       userId: payload.sub,
+      roleLevel: payload.role || 1,
     };
   }
 

--- a/src/users/dto/delete-account-response.dto.ts
+++ b/src/users/dto/delete-account-response.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteAccountResponseDto {
+  @ApiProperty({ example: true, description: '刪除是否成功' })
+  success: boolean;
+
+  @ApiProperty({ 
+    example: '帳號 (ID: 123) 及其關聯資料已徹底從系統移除。',
+    description: '操作結果訊息' 
+  })
+  message: string;
+
+  @ApiProperty({ 
+    example: 123,
+    description: '已刪除的使用者 ID' 
+  })
+  deletedUserId: number;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,11 +1,12 @@
 //（使用者資訊查詢 / 更新）
 
-import { Controller, Get, Patch, Body, Request, UseGuards } from '@nestjs/common';
+import { Controller, Get, Patch, Delete, Body, Request, UseGuards, HttpCode, HttpStatus, Query, ForbiddenException, BadRequestException } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
-import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { GetUserProfileResponseDto } from './dto/get-user-profile-response.dto';
+import { DeleteAccountResponseDto } from './dto/delete-account-response.dto';
 
 
 @ApiTags('Users')
@@ -27,5 +28,50 @@ export class UsersController {
   @ApiOperation({ summary: '更新使用者自己的個人資料' })
   updateMe(@Request() req, @Body() body: UpdateUserDto) {
     return this.usersService.updateProfile(req.user.userId, body);  
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete('me')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ 
+    summary: '清除帳號', 
+    description: '普通使用者可刪除自己的帳號。管理員可透過 Query 參數 targetId 刪除指定帳號。此操作會硬刪除帳號及其所有交易紀錄、金幣流水、IAP 收據。此操作不可逆，請謹慎使用。' 
+  })
+  @ApiQuery({ name: 'targetId', required: false, type: 'string', description: '要刪除的目標帳號 ID（僅限管理員使用）' })
+  @ApiResponse({ status: 200, description: '帳號已成功刪除', type: DeleteAccountResponseDto })
+  @ApiResponse({ status: 401, description: '未授權' })
+  @ApiResponse({ status: 403, description: '您沒有權限執行此操作' })
+  @ApiResponse({ status: 400, description: '請求參數無效' })
+  async deleteMyAccount(
+    @Request() req,
+    @Query('targetId') targetId?: string,
+  ): Promise<DeleteAccountResponseDto> {
+    const userId = req.user.userId;
+    const roleLevel = req.user.roleLevel || 1;
+    const isAdmin = roleLevel >= 9;
+
+    let accountToDelete = userId;
+
+    // 如果指定了 targetId，檢查管理員權限
+    if (targetId) {
+      if (!isAdmin) {
+        throw new ForbiddenException('只有管理員可以刪除其他帳號');
+      }
+      accountToDelete = parseInt(targetId, 10);
+      if (isNaN(accountToDelete)) {
+        throw new BadRequestException('無效的 targetId 格式');
+      }
+    }
+
+    await this.usersService.hardDeleteUser(accountToDelete, userId, isAdmin);
+
+    const deletedName = accountToDelete === userId ? '您的帳號' : `帳號 (ID: ${accountToDelete})`;
+    const operatorInfo = accountToDelete === userId ? '' : ` [操作者 ID: ${userId}]`;
+
+    return {
+      success: true,
+      message: `${deletedName}及其關聯資料已徹底從系統移除。${operatorInfo}`,
+      deletedUserId: accountToDelete,
+    };
   }
 }


### PR DESCRIPTION
- 新增 deleteMyAccount API 允許使用者刪除自己的帳號，管理員可刪除指定帳號
- 更新 AuthService 以支援角色等級的 JWT 生成
- 在 UsersController 中新增刪除帳號的 API
- 在 UsersService 中實作硬刪除使用者帳號的邏輯
- 新增 DeleteAccountResponseDto 以標準化刪除回應格式