### PR TITLE
feat(admin): 新增後台查詢用戶 IAP 交易紀錄的功能

### DIFF
--- a/src/auth/admin.guard.ts
+++ b/src/auth/admin.guard.ts
@@ -1,0 +1,20 @@
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+
+    if (!user) {
+      throw new ForbiddenException('未認證的使用者');
+    }
+
+    // roleLevel >= 9 表示 Admin
+    if (!user.roleLevel || user.roleLevel < 9) {
+      throw new ForbiddenException('只有管理員可存取此資源');
+    }
+
+    return true;
+  }
+}

--- a/src/iap/dto/admin-iap-receipts-query.dto.ts
+++ b/src/iap/dto/admin-iap-receipts-query.dto.ts
@@ -1,0 +1,22 @@
+import { Type } from 'class-transformer';
+import { IsInt, Min, Max, IsOptional } from 'class-validator';
+
+export class AdminIapReceiptsQueryDto {
+  @Type(() => Number)
+  @IsInt({ message: 'userId 必須是整數' })
+  @Min(1, { message: 'userId 必須大於 0' })
+  userId: number;
+
+  @IsOptional()
+  @IsInt({ message: 'page 必須是整數' })
+  @Min(1, { message: 'page 必須大於等於 1' })
+  @Type(() => Number)
+  page?: number = 1;
+
+  @IsOptional()
+  @IsInt({ message: 'limit 必須是整數' })
+  @Min(1, { message: 'limit 必須大於等於 1' })
+  @Max(100, { message: 'limit 最多 100' })
+  @Type(() => Number)
+  limit?: number = 20;
+}

--- a/src/iap/dto/admin-iap-receipts-response.dto.ts
+++ b/src/iap/dto/admin-iap-receipts-response.dto.ts
@@ -1,0 +1,26 @@
+export class AdminIapReceiptItemDto {
+  receiptId: string; // transaction_id
+  userId: number;
+  username: string;
+  email: string;
+  platform: 'GOOGLE' | 'APPLE';
+  productId: string;
+  productName: string;
+  price: string; // Decimal as string
+  currency: string;
+  baseCoins: number;
+  bonusCoins: number;
+  totalCoins: number;
+  status: string;
+  createdAt: Date;
+}
+
+export class AdminIapReceiptsResponseDto {
+  items: AdminIapReceiptItemDto[];
+  pagination: {
+    total: number;
+    page: number;
+    limit: number;
+    pages: number;
+  };
+}

--- a/src/iap/iap-query.controller.ts
+++ b/src/iap/iap-query.controller.ts
@@ -1,9 +1,13 @@
-import { Controller, Get, Req, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Controller, Get, Req, UseGuards, Query, BadRequestException } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AdminGuard } from '../auth/admin.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { IapQueryService } from './iap-query.service';
 import { MyIapReceiptDto } from './dto/my-iap-receipt.dto';
 import { MyIapReceiptsResponseDto } from './dto/my-iap-receipts-response.dto';
+import { AdminIapReceiptsQueryDto } from './dto/admin-iap-receipts-query.dto';
+import { AdminIapReceiptsResponseDto } from './dto/admin-iap-receipts-response.dto';
 
 @ApiTags('IAP / Coins')
 @ApiBearerAuth()
@@ -33,5 +37,99 @@ export class IapQueryController {
   @ApiOperation({ summary: '查詢我的金幣流水' })
   getMyCoinLedger(@Req() req) {
     return this.iapQueryService.getMyCoinLedger(req.user.userId);
+  }
+
+  @Get('admin/iap-receipts')
+  @UseGuards(AdminGuard)
+  @ApiOperation({ summary: '【後台】查詢用戶的 IAP 交易記錄' })
+  @ApiQuery({
+    name: 'userId',
+    description: '用戶 ID（必填）',
+    type: Number,
+    example: 123,
+    required: true,
+  })
+  @ApiQuery({
+    name: 'page',
+    description: '頁碼（可選，預設 1）',
+    type: Number,
+    example: 1,
+    required: false,
+  })
+  @ApiQuery({
+    name: 'limit',
+    description: '每頁筆數（可選，預設 20，最多 100）',
+    type: Number,
+    example: 20,
+    required: false,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '成功獲取用戶 IAP 交易記錄',
+    type: AdminIapReceiptsResponseDto,
+    example: {
+      items: [
+        {
+          receiptId: 'GPA.3218-2019-1234567890',
+          userId: 12,
+          username: 'John Doe',
+          email: 'john@example.com',
+          platform: 'GOOGLE',
+          productId: 'coins_100',
+          productName: '100 金幣',
+          price: '99.99',
+          currency: 'TWD',
+          baseCoins: 100,
+          bonusCoins: 10,
+          totalCoins: 110,
+          status: 'SUCCESS',
+          createdAt: '2026-02-27T10:30:00.000Z',
+        },
+        {
+          receiptId: '17000123456789012',
+          userId: 12,
+          username: 'John Doe',
+          email: 'john@example.com',
+          platform: 'APPLE',
+          productId: 'com.xstory.coins_500',
+          productName: '500 金幣',
+          price: '499.99',
+          currency: 'TWD',
+          baseCoins: 500,
+          bonusCoins: 50,
+          totalCoins: 550,
+          status: 'SUCCESS',
+          createdAt: '2026-02-26T15:20:00.000Z',
+        },
+      ],
+      pagination: {
+        total: 2,
+        page: 1,
+        limit: 20,
+        pages: 1,
+      },
+    },
+  })
+  @ApiResponse({
+    status: 403,
+    description: '無管理員權限',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'userId 必須是有效的整數',
+  })
+  async getAdminIapReceipts(
+    @Query() query: AdminIapReceiptsQueryDto,
+    @CurrentUser() user: any,
+  ): Promise<AdminIapReceiptsResponseDto> {
+    // 驗證 userId
+    if (!query.userId || query.userId <= 0) {
+      throw new BadRequestException('userId 必須是大於 0 的整數');
+    }
+
+    const page = query.page || 1;
+    const limit = query.limit || 20;
+
+    return this.iapQueryService.getAdminIapReceipts(query.userId, page, limit);
   }
 }

--- a/src/iap/iap.module.ts
+++ b/src/iap/iap.module.ts
@@ -6,8 +6,10 @@ import { IapService } from './iap.service'; // 導入 IapService
 import { IapQueryController } from './iap-query.controller';
 import { IapQueryService } from './iap-query.service';
 import { PrismaService } from '../prisma.service';
+import { UsersModule } from '../users/users.module'; // 導入 UsersModule
 
 @Module({
+    imports: [UsersModule], // 導入 UsersModule
     controllers: [CoinPacksController, IapController, IapQueryController], // 將 IapController 添加到 controllers 陣列
     providers: [CoinPacksService, IapService, IapQueryService, PrismaService], // 將 IapService 添加到 providers 陣列
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Auth API')
     .setDescription('多登入來源整合後端 API 文件')
-    .setVersion('1.5')
+    .setVersion('1.6')
     .addBearerAuth()
     .build();
 


### PR DESCRIPTION
-將 API 版本號從 1.5 更新至 1.6
- 新增 AdminGuard 以限制只有管理員可以存取該功能
- 新增 AdminIapReceiptsQueryDto 和 AdminIapReceiptsResponseDto 以處理查詢請求和回應
- 更新 IapQueryController 以支援查詢用戶的 IAP 交易紀錄
- 更新 IapQueryService 以實現查詢邏輯