### PR TITLE
feat: Implement Admin User Management and API Version Update

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Auth API')
     .setDescription('多登入來源整合後端 API 文件')
-    .setVersion('1.6')
+    .setVersion('1.7')
     .addBearerAuth()
     .build();
 


### PR DESCRIPTION
This commit introduces administrator capabilities for managing user profiles, alongside an update to the API version.

**Key Changes:**

- **AdminGuard:** A new `AdminGuard` has been created to restrict access to administrator-only routes based on the `roleLevel` (specifically, `roleLevel=9`).
- **UsersController:**
  - Added a new `PATCH /users/:targetId` endpoint. This allows administrators to update a specific user's profile, including their `roleLevel`.
  - The existing `PATCH /users/me` endpoint now uses the new `updateProfileWithPermissionCheck` method, preventing regular users from modifying their own `roleLevel`.
  - Implemented error handling for invalid user ID formats and forbidden access.
  - Swagger documentation has been updated for both `PATCH` endpoints, detailing their functionalities and expected responses.
- **UsersService:**
  - Introduced `updateProfileWithPermissionCheck` method. This method handles profile updates and incorporates a permission check to ensure only administrators can alter a user's `roleLevel`.
  - Refactored `updateProfile` into `updateProfileWithPermissionCheck` to centralize the update logic and permission enforcement.
- **API Version Update:** The API version in `src/main.ts` has been incremented from `1.6` to `1.7`.