### PR TITLE
feat(iap): add admin endpoint for coin ledger

### DIFF
--- a/src/iap/dto/admin-coin-ledger-query.dto.ts
+++ b/src/iap/dto/admin-coin-ledger-query.dto.ts
@@ -1,0 +1,22 @@
+import { Type } from 'class-transformer';
+import { IsInt, Min, Max, IsOptional } from 'class-validator';
+
+export class AdminCoinLedgerQueryDto {
+  @Type(() => Number)
+  @IsInt({ message: 'userId 必須是整數' })
+  @Min(1, { message: 'userId 必須大於 0' })
+  userId: number;
+
+  @IsOptional()
+  @IsInt({ message: 'page 必須是整數' })
+  @Min(1, { message: 'page 必須大於等於 1' })
+  @Type(() => Number)
+  page?: number = 1;
+
+  @IsOptional()
+  @IsInt({ message: 'limit 必須是整數' })
+  @Min(1, { message: 'limit 必須大於等於 1' })
+  @Max(100, { message: 'limit 最多 100' })
+  @Type(() => Number)
+  limit?: number = 20;
+}

--- a/src/iap/dto/admin-coin-ledger-response.dto.ts
+++ b/src/iap/dto/admin-coin-ledger-response.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AdminCoinLedgerDto } from './admin-coin-ledger.dto';
+
+export class PaginationDto {
+  @ApiProperty({ description: '總筆數', example: 100 })
+  total: number;
+
+  @ApiProperty({ description: '目前頁碼', example: 1 })
+  page: number;
+
+  @ApiProperty({ description: '每頁筆數', example: 20 })
+  limit: number;
+
+  @ApiProperty({ description: '總頁數', example: 5 })
+  pages: number;
+}
+
+export class AdminCoinLedgerResponseDto {
+  @ApiProperty({ type: [AdminCoinLedgerDto], description: '金幣流水列表' })
+  items: AdminCoinLedgerDto[];
+
+  @ApiProperty({ type: PaginationDto, description: '分頁資訊' })
+  pagination: PaginationDto;
+}

--- a/src/iap/dto/admin-coin-ledger.dto.ts
+++ b/src/iap/dto/admin-coin-ledger.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AdminCoinLedgerDto {
+  @ApiProperty({ description: '流水 ID', example: 101 })
+  id: number;
+
+  @ApiProperty({ description: '變動金額 (正數=增加, 負數=減少)', example: 100 })
+  amount: number;
+
+  @ApiProperty({ description: '變動後餘額', example: 1500 })
+  balance: number;
+
+  @ApiProperty({
+    description: '交易類型 (IAP=內購, IAP_BONUS=內購獎勵, USE=使用)',
+    example: 'IAP',
+  })
+  type: string;
+
+  @ApiProperty({
+    description: '來源備註 (例如: ORDER:GPA.1234|PROD:item_001)',
+    required: false,
+  })
+  source: string;
+
+  @ApiProperty({ description: '建立時間' })
+  createdAt: Date;
+
+  @ApiProperty({ description: '使用者 ID', example: 12 })
+  userId: number;
+
+  @ApiProperty({ description: '使用者名稱', example: 'John Doe' })
+  username: string;
+
+  @ApiProperty({ description: '使用者郵件', example: 'john@example.com' })
+  email: string;
+}

--- a/src/iap/iap-query.controller.ts
+++ b/src/iap/iap-query.controller.ts
@@ -8,6 +8,8 @@ import { MyIapReceiptDto } from './dto/my-iap-receipt.dto';
 import { MyIapReceiptsResponseDto } from './dto/my-iap-receipts-response.dto';
 import { AdminIapReceiptsQueryDto } from './dto/admin-iap-receipts-query.dto';
 import { AdminIapReceiptsResponseDto } from './dto/admin-iap-receipts-response.dto';
+import { AdminCoinLedgerQueryDto } from './dto/admin-coin-ledger-query.dto';
+import { AdminCoinLedgerResponseDto } from './dto/admin-coin-ledger-response.dto';
 
 @ApiTags('IAP / Coins')
 @ApiBearerAuth()
@@ -131,5 +133,89 @@ export class IapQueryController {
     const limit = query.limit || 20;
 
     return this.iapQueryService.getAdminIapReceipts(query.userId, page, limit);
+  }
+
+  @Get('admin/coins/ledger')
+  @UseGuards(AdminGuard)
+  @ApiOperation({ summary: '【後台】查詢用戶的金幣流水' })
+  @ApiQuery({
+    name: 'userId',
+    description: '用戶 ID（必填）',
+    type: Number,
+    example: 123,
+    required: true,
+  })
+  @ApiQuery({
+    name: 'page',
+    description: '頁碼（可選，預設 1）',
+    type: Number,
+    example: 1,
+    required: false,
+  })
+  @ApiQuery({
+    name: 'limit',
+    description: '每頁筆數（可選，預設 20，最多 100）',
+    type: Number,
+    example: 20,
+    required: false,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '成功獲取用戶金幣流水',
+    type: AdminCoinLedgerResponseDto,
+    example: {
+      items: [
+        {
+          id: 101,
+          amount: 100,
+          balance: 1500,
+          type: 'IAP',
+          source: 'ORDER:GPA.1234|PROD:coins_100',
+          createdAt: '2026-02-27T10:30:00.000Z',
+          userId: 12,
+          username: 'John Doe',
+          email: 'john@example.com',
+        },
+        {
+          id: 100,
+          amount: -50,
+          balance: 1400,
+          type: 'USE',
+          source: 'SHOP:book_001',
+          createdAt: '2026-02-26T15:20:00.000Z',
+          userId: 12,
+          username: 'John Doe',
+          email: 'john@example.com',
+        },
+      ],
+      pagination: {
+        total: 100,
+        page: 1,
+        limit: 20,
+        pages: 5,
+      },
+    },
+  })
+  @ApiResponse({
+    status: 403,
+    description: '無管理員權限',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'userId 必須是有效的整數',
+  })
+  async getAdminCoinLedger(
+    @Query() query: AdminCoinLedgerQueryDto,
+    @CurrentUser() user: any,
+  ): Promise<AdminCoinLedgerResponseDto> {
+    // 驗證 userId
+    if (!query.userId || query.userId <= 0) {
+      throw new BadRequestException('userId 必須是大於 0 的整數');
+    }
+
+    const page = query.page || 1;
+    const limit = query.limit || 20;
+
+    return this.iapQueryService.getAdminCoinLedger(query.userId, page, limit);
   }
 }


### PR DESCRIPTION
This commit introduces a new admin endpoint to retrieve a user's coin ledger.

The new endpoint `/iap/admin/coins/ledger` allows administrators to query the coin transaction history for a specific user. It includes pagination and detailed information about each transaction, such as amount, balance, type, and source.

This feature is crucial for administrative oversight and auditing of user coin activities.

Changes include:
- Added `getAdminCoinLedger` method to `IapQueryController` with `@ApiTags`, `@ApiOperation`, `@ApiQuery`, and `@ApiResponse` decorators for Swagger documentation.
- Implemented `getAdminCoinLedger` in `IapQueryService` to fetch coin ledger data from the database using raw SQL queries and integrate user profile information.
- Imported `AdminCoinLedgerQueryDto` and `AdminCoinLedgerResponseDto` in the controller and service respectively.