### PR TITLE
feat(bookstore): 新增管理員查詢用戶權益列表的 API 及相關 DTO

### DIFF
--- a/src/bookstore/bookstore.controller.ts
+++ b/src/bookstore/bookstore.controller.ts
@@ -1,9 +1,12 @@
-import { Controller, Get, Query, UseGuards, Logger } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards, Logger, BadRequestException, ValidationPipe } from '@nestjs/common';
 import { BookstoreService } from './bookstore.service';
 import { ApiTags, ApiOperation, ApiResponse, ApiUnauthorizedResponse, ApiForbiddenResponse, ApiInternalServerErrorResponse, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
 import { BookstoreItemDto } from './dto/get-bookstore-list-response.dto';
 import { GetMyEntitlementsResponseDto } from './dto/get-my-entitlements-response.dto';
+import { AdminEntitlementsQueryDto } from './dto/admin-entitlements-query.dto';
+import { AdminEntitlementsResponseDto } from './dto/admin-entitlements-response.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AdminGuard } from '../auth/admin.guard';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 
 @ApiTags('BookStore')
@@ -108,5 +111,126 @@ export class BookstoreController {
     this.logger.log(`🔵 [BookstoreController] 查詢分頁: page=${pageNum}, limit=${limitNum}`);
 
     return this.bookstoreService.getUserEntitlements(user.userId, pageNum, limitNum);
+  }
+
+  @Get('admin/entitlements')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: '【後台】查詢用戶的書籍列表',
+    description: '管理員可透過此 API 查詢任意用戶擁有的書籍列表（權益列表）。需驗證 JWT Token 且 roleLevel >= 9',
+  })
+  @ApiQuery({
+    name: 'userId',
+    description: '用戶 ID（必填）- 必須為整數且大於 0',
+    type: Number,
+    example: 123,
+    required: true,
+  })
+  @ApiQuery({
+    name: 'page',
+    description: '頁碼（可選，預設 1）',
+    type: Number,
+    example: 1,
+    required: false,
+  })
+  @ApiQuery({
+    name: 'limit',
+    description: '每頁筆數（可選，預設 20，最多 100）',
+    type: Number,
+    example: 20,
+    required: false,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '成功取得用戶的書籍列表',
+    type: AdminEntitlementsResponseDto,
+    example: {
+      user: {
+        id: 123,
+        username: 'John Doe',
+        email: 'john@example.com',
+      },
+      entitlements: [
+        {
+          book: {
+            id: 1,
+            title: '小鎮失蹤手冊',
+            author: '夏佩爾&烏奴奴',
+            coverImage: 'mainMenuImage-1709644166964.jpeg',
+          },
+          purchasedAt: '2026-02-20T10:30:00.000Z',
+        },
+        {
+          book: {
+            id: 2,
+            title: '冒險故事',
+            author: '張三',
+            coverImage: 'cover-image-2.jpeg',
+          },
+          purchasedAt: '2026-02-15T14:20:00.000Z',
+        },
+      ],
+      pagination: {
+        total: 5,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'userId 驗證失敗 - 必須為整數且大於 0',
+    schema: {
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: {
+          oneOf: [
+            { type: 'string', example: 'userId 必須是有效的數字' },
+            { type: 'string', example: 'userId 必須是整數' },
+            { type: 'string', example: 'userId 必須大於 0' },
+          ],
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 403,
+    description: '無管理員權限 - roleLevel < 9 或未認證',
+    schema: {
+      properties: {
+        statusCode: { type: 'number', example: 403 },
+        message: { type: 'string', example: '只有管理員可存取此資源' },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 500,
+    description: '伺服器錯誤 - 資料庫連線失敗',
+    schema: {
+      properties: {
+        statusCode: { type: 'number', example: 500 },
+        message: { type: 'object', example: { success: false, message: '資料庫連線失敗' } },
+      },
+    },
+  })
+  async getAdminEntitlements(
+    @Query(new ValidationPipe({ transform: true, transformOptions: { enableImplicitConversion: true } }))
+    query: AdminEntitlementsQueryDto,
+    @CurrentUser() user: any,
+  ): Promise<AdminEntitlementsResponseDto> {
+    this.logger.log(`🔵 [BookstoreController] getAdminEntitlements() 被呼叫`);
+    this.logger.log(`🔵 [BookstoreController] 管理員 ID: ${user?.userId}, 目標用戶 ID: ${query.userId}`);
+
+    // 執行查詢
+    const page = query.page || 1;
+    const limit = query.limit || 20;
+
+    this.logger.log(
+      `🔵 [BookstoreController] 查詢用戶 ${query.userId} 的權益，分頁: page=${page}, limit=${limit}`,
+    );
+
+    return this.bookstoreService.getAdminEntitlements(query.userId, page, limit);
   }
 }

--- a/src/bookstore/bookstore.service.ts
+++ b/src/bookstore/bookstore.service.ts
@@ -105,4 +105,134 @@ export class BookstoreService {
       throw new InternalServerErrorException({ success: false, message: '資料庫連線失敗' });
     }
   }
+
+  /**
+   * 【後台管理員專用】取得指定用戶已購買的書籍列表（權益列表）
+   * - 包含用戶基本資訊（ID、username、email）
+   * - 包含用戶已購買的書籍列表，以購買日期由新至舊排序
+   * - 支援分頁查詢
+   *
+   * @param userId 目標用戶 ID
+   * @param page 頁碼（預設 1）
+   * @param limit 每頁筆數（預設 20，最多 100）
+   * @returns 包含用戶資訊、權益列表與分頁資訊的物件
+   * @throws InternalServerErrorException 資料庫連線失敗時
+   */
+  async getAdminEntitlements(
+    userId: number,
+    page: number = 1,
+    limit: number = 20,
+  ) {
+    try {
+      // 驗證分頁參數
+      const pageNum = Math.max(1, page);
+      const limitNum = Math.min(100, Math.max(1, limit)); // 限制最多 100 筆
+      const skip = (pageNum - 1) * limitNum;
+
+      // 並行查詢：取得用戶資訊與權益總數
+      const [user, entitlementCount] = await Promise.all([
+        this.prisma.user.findUnique({
+          where: { id: userId },
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        }),
+        this.prisma.entitlements.count({
+          where: {
+            user_id: BigInt(userId),
+          },
+        }),
+      ]);
+
+      // 若用戶不存在，返回用戶不存在的結構
+      if (!user) {
+        return {
+          user: null,
+          entitlements: [],
+          pagination: {
+            total: 0,
+            page: pageNum,
+            limit: limitNum,
+            totalPages: 0,
+          },
+        };
+      }
+
+      // 查詢用戶的權益列表（已購買的書籍）
+      const entitlements = await this.prisma.entitlements.findMany({
+        where: {
+          user_id: BigInt(userId),
+        },
+        select: {
+          story_list_id: true,
+          created_at: true,
+        },
+        orderBy: {
+          created_at: 'desc', // 按購買日期最新優先
+        },
+        skip,
+        take: limitNum,
+      });
+
+      // 獲取關聯的故事資訊
+      const storyListIds = entitlements.map((e) => e.story_list_id);
+      let stories = [];
+
+      if (storyListIds.length > 0) {
+        stories = await this.prisma.storyLists.findMany({
+          where: {
+            id: { in: storyListIds },
+          },
+          select: {
+            id: true,
+            main_menu_name: true,
+            author: true,
+            main_menu_image: true,
+          },
+        });
+      }
+
+      // 建立 story ID 的 Map 以加速查詢
+      const storyMap = new Map(stories.map((s) => [s.id, s]));
+
+      // 組合權益列表
+      const entitlementList = entitlements.map((entitled) => {
+        const story = storyMap.get(entitled.story_list_id);
+        return {
+          book: {
+            id: entitled.story_list_id,
+            title: story?.main_menu_name ?? 'Unknown Book',
+            author: story?.author ?? 'Unknown Author',
+            coverImage: story?.main_menu_image ?? '',
+          },
+          purchasedAt: entitled.created_at,
+        };
+      });
+
+      // 計算總頁數
+      const totalPages = Math.ceil(entitlementCount / limitNum);
+
+      return {
+        user: {
+          id: user.id,
+          username: user.name || 'Unknown',
+          email: user.email,
+        },
+        entitlements: entitlementList,
+        pagination: {
+          total: entitlementCount,
+          page: pageNum,
+          limit: limitNum,
+          totalPages,
+        },
+      };
+    } catch (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: '資料庫連線失敗',
+      });
+    }
+  }
 }

--- a/src/bookstore/dto/admin-entitlements-query.dto.ts
+++ b/src/bookstore/dto/admin-entitlements-query.dto.ts
@@ -1,0 +1,50 @@
+import { IsNumber, IsInt, IsPositive, IsOptional, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * 管理後台查詢用戶權益列表的查詢參數 DTO
+ * - userId: 必填，目標用戶 ID
+ * - page: 可選，分頁頁碼（預設 1）
+ * - limit: 可選，每頁筆數（預設 20，最多 100）
+ */
+export class AdminEntitlementsQueryDto {
+  /** 用戶 ID（必填）- 必須為大於 0 的整數 */
+  @ApiProperty({
+    example: 123,
+    description: '用戶 ID（必填）- 必須為大於 0 的整數',
+    type: Number,
+  })
+  @IsNumber({ allowNaN: false }, { message: 'userId 必須是有效的數字' })
+  @IsInt({ message: 'userId 必須是整數' })
+  @IsPositive({ message: 'userId 必須大於 0' })
+  @Type(() => Number)
+  userId!: number;
+
+  /** 頁碼（可選，預設 1） */
+  @ApiProperty({
+    example: 1,
+    description: '頁碼（可選，預設 1）',
+    type: Number,
+    required: false,
+  })
+  @IsOptional()
+  @IsInt({ message: 'page 必須是整數' })
+  @Min(1, { message: 'page 最小為 1' })
+  @Type(() => Number)
+  page?: number = 1;
+
+  /** 每頁筆數（可選，預設 20，最多 100） */
+  @ApiProperty({
+    example: 20,
+    description: '每頁筆數（可選，預設 20，最多 100）',
+    type: Number,
+    required: false,
+  })
+  @IsOptional()
+  @IsInt({ message: 'limit 必須是整數' })
+  @Min(1, { message: 'limit 最小為 1' })
+  @Max(100, { message: 'limit 最多為 100' })
+  @Type(() => Number)
+  limit?: number = 20;
+}

--- a/src/bookstore/dto/admin-entitlements-response.dto.ts
+++ b/src/bookstore/dto/admin-entitlements-response.dto.ts
@@ -1,0 +1,111 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * 用戶基本資訊 DTO
+ * - 包含用戶的 ID、username、email
+ */
+export class UserBasicInfoDto {
+  /** 用戶 ID */
+  @ApiProperty({ example: 123, description: '用戶 ID' })
+  id!: number;
+
+  /** 用戶名稱 */
+  @ApiProperty({ example: 'John Doe', description: '用戶名稱' })
+  username!: string;
+
+  /** 用戶電子郵件 */
+  @ApiProperty({ example: 'john@example.com', description: '用戶電子郵件' })
+  email!: string;
+}
+
+/**
+ * 書籍基本資訊 DTO
+ * - 用戶已購買書籍的詳細資訊
+ */
+export class BookBasicInfoDto {
+  /** 故事 ID */
+  @ApiProperty({ example: 1, description: '故事 ID' })
+  id!: number;
+
+  /** 書籍名稱 */
+  @ApiProperty({
+    example: '小鎮失蹤手冊',
+    description: '書籍名稱',
+  })
+  title!: string;
+
+  /** 作者名稱 */
+  @ApiProperty({
+    example: '夏佩爾&烏奴奴',
+    description: '作者名稱',
+  })
+  author!: string;
+
+  /** 封面圖片 */
+  @ApiProperty({
+    example: 'mainMenuImage-1709644166964.jpeg',
+    description: '封面圖片 URL',
+  })
+  coverImage!: string;
+}
+
+/**
+ * 用戶權益記錄 DTO
+ * - 對應單個 entitlements 記錄（用戶已購買的一本書）
+ */
+export class EntitlementRecordDto {
+  /** 書籍資訊 */
+  @ApiProperty({ type: () => BookBasicInfoDto, description: '書籍資訊' })
+  book!: BookBasicInfoDto;
+
+  /** 購買日期 */
+  @ApiProperty({
+    example: '2026-02-20T10:30:00.000Z',
+    description: '購買日期（ISO 8601 格式）',
+  })
+  purchasedAt!: Date;
+}
+
+/**
+ * 分頁資訊 DTO
+ * - 分頁的元數據
+ */
+export class PaginationDto {
+  /** 總筆數 */
+  @ApiProperty({ example: 25, description: '總筆數' })
+  total!: number;
+
+  /** 當前頁碼 */
+  @ApiProperty({ example: 1, description: '當前頁碼' })
+  page!: number;
+
+  /** 每頁筆數 */
+  @ApiProperty({ example: 20, description: '每頁筆數' })
+  limit!: number;
+
+  /** 總頁數 */
+  @ApiProperty({ example: 2, description: '總頁數' })
+  totalPages!: number;
+}
+
+/**
+ * 管理後台查詢用戶權益列表的響應 DTO
+ * - 包含用戶基本資訊、使用者已購買的書籍列表與分頁資訊
+ */
+export class AdminEntitlementsResponseDto {
+  /** 用戶基本資訊（當用戶不存在時為 null） */
+  @ApiProperty({ type: () => UserBasicInfoDto, description: '用戶基本資訊（當用戶不存在時為 null）', nullable: true })
+  user!: UserBasicInfoDto | null;
+
+  /** 用戶已購買的書籍列表 */
+  @ApiProperty({
+    type: () => [EntitlementRecordDto],
+    description: '用戶已購買的書籍列表',
+    isArray: true,
+  })
+  entitlements!: EntitlementRecordDto[];
+
+  /** 分頁資訊 */
+  @ApiProperty({ type: () => PaginationDto, description: '分頁資訊' })
+  pagination!: PaginationDto;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Auth API')
     .setDescription('烏努努小說平台後端 API 文件')
-    .setVersion('1.9')
+    .setVersion('1.9.1')
     .addBearerAuth()
     .build();
 


### PR DESCRIPTION
- 將 API 版本號從 1.9.1 更新至 1.9.2

1. **Endpoint**: `GET /admin/entitlements`
2. **功能**: 查詢指定會員擁有的書籍列表（權限列表）
3. **權限控制**: 
   - 必須經過 `AdminGuard` 驗證。
   - 檢查邏輯：`user.roleLevel >= 9`。
4. **參數驗證**: 
   - 查詢參數為 `userId`。
   - `userId` 必須為整數且大於 0。
5. **資料返回**: 
   - 需包含該用戶的基本資訊（username, email）。
   - 需包含該用戶擁有的書籍列表。