### PR TITLE
feat(admin): 建立新的金幣儲值包商品

### DIFF
--- a/src/iap/coin-packs.controller.ts
+++ b/src/iap/coin-packs.controller.ts
@@ -1,8 +1,30 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Query,
+  Body,
+  HttpCode,
+  UseGuards,
+  HttpException,
+} from '@nestjs/common';
 import { CoinPacksService } from './coin-packs.service';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiBadRequestResponse,
+  ApiForbiddenResponse,
+} from '@nestjs/swagger';
 import { GetCoinPacksRequestDto } from './dto/get-coin-packs-request.dto';
 import { GetCoinPacksResponseDto } from './dto/get-coin-packs-response.dto';
+import { CreateCoinPackRequestDto } from './dto/create-coin-pack-request.dto';
+import { CreateCoinPackResponseDto } from './dto/create-coin-pack-response.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AdminGuard } from '../auth/admin.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
 
 @ApiTags('IAP - Coin Packs')
 @Controller('coin-packs')
@@ -53,5 +75,88 @@ export class CoinPacksController {
       success: true, 
       data: formattedPacks 
     };
+  }
+
+  /**
+   * 建立金幣儲值包 (Admin Only)
+   * @description 僅限管理員使用，用於建立新的金幣儲值包商品
+   * @requires JWT Token + Admin 權限 (roleLevel >= 9)
+   */
+  @Post()
+  @HttpCode(201)
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: '建立金幣儲值包 (管理員專用)',
+    description: '建立新的金幣儲值包商品。需要 JWT Token 且用戶 roleLevel >= 9 (Admin)。',
+  })
+  @ApiCreatedResponse({
+    description: '成功建立金幣儲值包',
+    type: CreateCoinPackResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: '參數驗證失敗或重複的 platform + productId 組合',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: 'validation failed: ...',
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiForbiddenResponse({
+    description: '權限不足 (需要 Admin 權限)',
+    schema: {
+      example: {
+        message: '只有管理員可存取此資源',
+        error: 'Forbidden',
+        statusCode: 403,
+      },
+    },
+  })
+  async create(
+    @Body() createCoinPackDto: CreateCoinPackRequestDto,
+    @CurrentUser() user: any,
+  ): Promise<CreateCoinPackResponseDto> {
+    try {
+      // 權限檢查：AdminGuard 已確保 user.roleLevel >= 9
+      // (此檢查邏輯由 AdminGuard 執行，這裡作為註釋說明)
+      // if (!user || user.roleLevel < 9) {
+      //   throw new ForbiddenException('只有管理員可存取此資源');
+      // }
+
+      // 調用 Service 建立金幣儲值包
+      const coinPack = await this.coinPacksService.create(createCoinPackDto);
+
+      // 資料轉換 (Decimal → Number)
+      const response: CreateCoinPackResponseDto = {
+        success: true,
+        message: 'Created successfully',
+        data: {
+          id: coinPack.id,
+          platform: coinPack.platform as 'GOOGLE' | 'APPLE',
+          productId: coinPack.productId,
+          name: coinPack.name,
+          amount: coinPack.amount,
+          bonusAmount: coinPack.bonusAmount,
+          price: Number(coinPack.price),
+          currency: coinPack.currency,
+          isActive: coinPack.isActive,
+          sortOrder: coinPack.sortOrder,
+          createdAt: coinPack.createdAt,
+          updatedAt: coinPack.updatedAt,
+        },
+      };
+
+      return response;
+    } catch (error) {
+      // HttpException 已由 Service 層或 Guard 拋出，直接拋出
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
+      // 其他未預期的錯誤
+      throw new HttpException('建立金幣儲值包失敗', 500);
+    }
   }
 }

--- a/src/iap/coin-packs.service.ts
+++ b/src/iap/coin-packs.service.ts
@@ -1,8 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException, InternalServerErrorException, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
+import { CreateCoinPackRequestDto } from './dto/create-coin-pack-request.dto';
 
 @Injectable()
 export class CoinPacksService {
+  private readonly logger = new Logger(CoinPacksService.name);
+
   constructor(private readonly prisma: PrismaService) {}
 
   /**
@@ -33,5 +36,71 @@ export class CoinPacksService {
       //   platform: true,
       // }
     });
+  }
+
+  /**
+   * 建立金幣儲值包 (Admin Only)
+   * @param createCoinPackDto 金幣儲值包資料
+   * @returns 建立的金幣儲值包
+   * @throws BadRequestException - 當 platform + productId 已存在或參數不合法
+   * @throws InternalServerErrorException - 資料庫操作失敗
+   */
+  async create(createCoinPackDto: CreateCoinPackRequestDto) {
+    try {
+      // 檢查 platform + productId 的組合是否已存在
+      const existingPack = await this.prisma.coinPack.findUnique({
+        where: {
+          platform_productId: {
+            platform: createCoinPackDto.platform,
+            productId: createCoinPackDto.product_id,
+          },
+        },
+      });
+
+      if (existingPack) {
+        this.logger.warn(
+          `Duplicate coin pack attempt: platform=${createCoinPackDto.platform}, productId=${createCoinPackDto.product_id}`,
+        );
+        throw new BadRequestException(
+          `此 platform (${createCoinPackDto.platform}) 已存在相同的 productId (${createCoinPackDto.product_id})`,
+        );
+      }
+
+      // 建立新的金幣儲值包
+      const coinPack = await this.prisma.coinPack.create({
+        data: {
+          platform: createCoinPackDto.platform,
+          productId: createCoinPackDto.product_id,
+          name: createCoinPackDto.name,
+          amount: createCoinPackDto.amount,
+          bonusAmount: createCoinPackDto.bonusAmount || 0,
+          price: createCoinPackDto.price,
+          currency: createCoinPackDto.currency || 'TWD',
+          isActive: createCoinPackDto.is_active === 0 ? false : true,
+          sortOrder: 999, // 預設排序權重，管理員可後續調整
+        },
+      });
+
+      this.logger.log(
+        `Successfully created coin pack: id=${coinPack.id}, platform=${coinPack.platform}, productId=${coinPack.productId}`,
+      );
+
+      return coinPack;
+    } catch (error) {
+      // P2002 是 Prisma 的唯一約束違反錯誤代碼
+      if (error.code === 'P2002') {
+        this.logger.warn(`Unique constraint violation: ${error.message}`);
+        throw new BadRequestException('此 platform 與 productId 的組合已存在');
+      }
+
+      // 如果已經是 HttpException，直接拋出
+      if (error.status) {
+        throw error;
+      }
+
+      // 其他未預期的錯誤
+      this.logger.error(`Failed to create coin pack: ${error.message}`, error.stack);
+      throw new InternalServerErrorException('建立金幣儲值包失敗，請稍後重試');
+    }
   }
 }

--- a/src/iap/dto/create-coin-pack-request.dto.ts
+++ b/src/iap/dto/create-coin-pack-request.dto.ts
@@ -1,0 +1,135 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  MinLength,
+  MaxLength,
+  IsNumber,
+  Min,
+  IsOptional,
+  IsEnum,
+  IsInt,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * @description 建立金幣儲值包的請求 DTO
+ */
+export class CreateCoinPackRequestDto {
+  /**
+   * @description 平台類型 (GOOGLE 或 APPLE)
+   * @example GOOGLE
+   */
+  @ApiProperty({
+    description: '平台類型',
+    enum: ['GOOGLE', 'APPLE'],
+    example: 'GOOGLE',
+  })
+  @IsNotEmpty({ message: '平台類型不能為空' })
+  @IsEnum(['GOOGLE', 'APPLE'], { message: '平台類型只能為 GOOGLE 或 APPLE' })
+  @IsString({ message: '平台類型必須為字串' })
+  @MinLength(2, { message: '平台類型長度不能少於 2 個字元' })
+  @MaxLength(20, { message: '平台類型長度不能超過 20 個字元' })
+  platform: 'GOOGLE' | 'APPLE';
+
+  /**
+   * @description 商品 ID (SKU)
+   * @example test_item_001
+   */
+  @ApiProperty({
+    description: '商品 ID (SKU)，用於區分不同商品',
+    example: 'test_item_001',
+  })
+  @IsNotEmpty({ message: '商品 ID 不能為空' })
+  @IsString({ message: '商品 ID 必須為字串' })
+  @MinLength(2, { message: '商品 ID 長度不能少於 2 個字元' })
+  @MaxLength(100, { message: '商品 ID 長度不能超過 100 個字元' })
+  product_id: string;
+
+  /**
+   * @description 商品名稱
+   * @example 90 金幣 + 5 Bonus
+   */
+  @ApiProperty({
+    description: '商品名稱，用於顯示給用戶',
+    example: '90 金幣 + 5 Bonus',
+  })
+  @IsNotEmpty({ message: '商品名稱不能為空' })
+  @IsString({ message: '商品名稱必須為字串' })
+  @MinLength(2, { message: '商品名稱長度不能少於 2 個字元' })
+  @MaxLength(100, { message: '商品名稱長度不能超過 100 個字元' })
+  name: string;
+
+  /**
+   * @description 基礎金幣數量
+   * @example 90
+   */
+  @ApiProperty({
+    description: '基礎金幣數量，最少 10 枚',
+    example: 90,
+  })
+  @IsNotEmpty({ message: '基礎金幣數量不能為空' })
+  @Type(() => Number)
+  @IsInt({ message: '基礎金幣數量必須為整數' })
+  @Min(10, { message: '基礎金幣數量最少為 10 枚' })
+  amount: number;
+
+  /**
+   * @description 贈送金幣數量 (可選，預設 0)
+   * @example 5
+   */
+  @ApiProperty({
+    description: '贈送金幣數量 (可選)，預設為 0',
+    example: 5,
+    required: false,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: '贈送金幣數量必須為整數' })
+  @Min(0, { message: '贈送金幣數量最少為 0 枚' })
+  bonusAmount?: number = 0;
+
+  /**
+   * @description 商品價格
+   * @example 90.99
+   */
+  @ApiProperty({
+    description: '商品價格，必須大於 0',
+    example: 90.99,
+  })
+  @IsNotEmpty({ message: '商品價格不能為空' })
+  @Type(() => Number)
+  @IsNumber({ allowInfinity: false, allowNaN: false }, { message: '商品價格必須為有效的數字' })
+  @Min(0.01, { message: '商品價格必須大於 0' })
+  price: number;
+
+  /**
+   * @description 幣別 (可選，預設 TWD)
+   * @example TWD
+   */
+  @ApiProperty({
+    description: '幣別，可選值為 TWD, USD, JPY (預設: TWD)',
+    enum: ['TWD', 'USD', 'JPY'],
+    example: 'TWD',
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(['TWD', 'USD', 'JPY'], { message: '幣別只能為 TWD, USD 或 JPY' })
+  @IsString({ message: '幣別必須為字串' })
+  currency?: string = 'TWD';
+
+  /**
+   * @description 是否上架 (可選，預設 1 表示上架)
+   * @example 1
+   */
+  @ApiProperty({
+    description: '是否上架 (1: 上架, 0: 下架，預設: 1)',
+    example: 1,
+    required: false,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'is_active 必須為整數' })
+  @IsEnum([0, 1], { message: 'is_active 只能為 0 或 1' })
+  is_active?: number = 1;
+}

--- a/src/iap/dto/create-coin-pack-response.dto.ts
+++ b/src/iap/dto/create-coin-pack-response.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * @description 建立金幣儲值包的回應 DTO
+ */
+export class CreateCoinPackResponseDto {
+  /**
+   * @description 請求是否成功
+   * @example true
+   */
+  @ApiProperty({
+    description: '請求是否成功',
+    example: true,
+  })
+  success: boolean;
+
+  /**
+   * @description 操作訊息
+   * @example Created successfully
+   */
+  @ApiProperty({
+    description: '操作訊息',
+    example: 'Created successfully',
+  })
+  message: string;
+
+  /**
+   * @description 建立的金幣儲值包資料
+   */
+  @ApiProperty({
+    description: '建立的金幣儲值包資料',
+    type: 'object',
+    properties: {
+      id: { type: 'number', example: 1 },
+      platform: { type: 'string', enum: ['GOOGLE', 'APPLE'], example: 'GOOGLE' },
+      productId: { type: 'string', example: 'com.example.coins.100' },
+      name: { type: 'string', example: '90 金幣 + 5 Bonus' },
+      amount: { type: 'number', example: 90 },
+      bonusAmount: { type: 'number', example: 5 },
+      price: { type: 'number', example: 90.99 },
+      currency: { type: 'string', example: 'TWD' },
+      isActive: { type: 'boolean', example: true },
+      sortOrder: { type: 'number', example: 999 },
+      createdAt: { type: 'string', format: 'date-time' },
+      updatedAt: { type: 'string', format: 'date-time' },
+    },
+  })
+  data: {
+    id: number;
+    platform: 'GOOGLE' | 'APPLE';
+    productId: string;
+    name: string;
+    amount: number;
+    bonusAmount: number;
+    price: number;
+    currency: string;
+    isActive: boolean;
+    sortOrder: number;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Auth API')
     .setDescription('烏努努小說平台後端 API 文件')
-    .setVersion('1.9.1')
+    .setVersion('1.9.3')
     .addBearerAuth()
     .build();
 


### PR DESCRIPTION
-將 API 版本號從 1.9.1 更新至 1.9.3
- 新增**Endpoint**: `POST /api/admin/coin-packs`
  - **功能**: 建立新的金幣儲值包商品
  - **權限**: 僅限管理員 (Admin) 存取，需提供 JWT Token 且用戶 roleLevel >= 9
  - **請求參數**: CreateCoinPackRequestDto (包含平台類型、商品 ID、名稱、金幣數量、價格等資訊)
  - **回應格式**: CreateCoinPackResponseDto (包含成功狀態、訊息和建立的金幣儲值包資料)
- 新增 CoinPacksController 的 create 方法以處理建立金幣儲值包的請求
- 新增 AdminGuard 以限制只有管理員可以存取該功能
