### PR TITLE
feat(admin): 新增管理員更新金幣儲值包的 API 及相關 DTO

### DIFF
--- a/src/iap/coin-packs.controller.ts
+++ b/src/iap/coin-packs.controller.ts
@@ -2,11 +2,14 @@ import {
   Controller,
   Get,
   Post,
+  Patch,
   Query,
   Body,
+  Param,
   HttpCode,
   UseGuards,
   HttpException,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { CoinPacksService } from './coin-packs.service';
 import {
@@ -15,13 +18,18 @@ import {
   ApiResponse,
   ApiBearerAuth,
   ApiCreatedResponse,
+  ApiOkResponse,
   ApiBadRequestResponse,
   ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiParam,
 } from '@nestjs/swagger';
 import { GetCoinPacksRequestDto } from './dto/get-coin-packs-request.dto';
 import { GetCoinPacksResponseDto } from './dto/get-coin-packs-response.dto';
 import { CreateCoinPackRequestDto } from './dto/create-coin-pack-request.dto';
 import { CreateCoinPackResponseDto } from './dto/create-coin-pack-response.dto';
+import { UpdateCoinPackAdminRequestDto } from './dto/update-coin-pack-admin-request.dto';
+import { UpdateCoinPackAdminResponseDto } from './dto/update-coin-pack-admin-response.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AdminGuard } from '../auth/admin.guard';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
@@ -157,6 +165,108 @@ export class CoinPacksController {
 
       // 其他未預期的錯誤
       throw new HttpException('建立金幣儲值包失敗', 500);
+    }
+  }
+
+  /**
+   * 更新金幣儲值包 (Admin Only) - 用於上下架管理
+   * @description 管理員可透過此端點更新金幣商品的 platform、product_id、name 和 is_active（上下架狀態）
+   * @requires JWT Token + Admin 權限 (roleLevel >= 9)
+   */
+  @Patch(':id')
+  @HttpCode(200)
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @ApiBearerAuth()
+  @ApiParam({
+    name: 'id',
+    description: '金幣儲值包 ID',
+    example: 1,
+  })
+  @ApiOperation({
+    summary: '更新金幣儲值包 (管理員專用)',
+    description: '更新既有的金幣儲值包商品，支援更改 platform、product_id、name 和上下架狀態 (is_active)。需要 JWT Token 且用戶 roleLevel >= 9 (Admin)。',
+  })
+  @ApiOkResponse({
+    description: '成功更新金幣儲值包',
+    type: UpdateCoinPackAdminResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: '參數驗證失敗或重複的 platform + productId 組合',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: '此 platform 與 productId 的組合已存在',
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiForbiddenResponse({
+    description: '權限不足 (需要 Admin 權限，roleLevel >= 9)',
+    schema: {
+      example: {
+        message: '只有管理員可存取此資源',
+        error: 'Forbidden',
+        statusCode: 403,
+      },
+    },
+  })
+  @ApiNotFoundResponse({
+    description: '指定 ID 的金幣儲值包不存在',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: '金幣儲值包不存在 (ID: 999)',
+        error: 'Not Found',
+      },
+    },
+  })
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateCoinPackAdminDto: UpdateCoinPackAdminRequestDto,
+    @CurrentUser() user: any,
+  ): Promise<UpdateCoinPackAdminResponseDto> {
+    try {
+      // 權限檢查：AdminGuard 已確保 user.roleLevel >= 9
+      // 此檢查邏輯由 AdminGuard 執行，以下作為註釋說明
+      // if (!user || user.roleLevel < 9) {
+      //   throw new ForbiddenException('只有管理員可存取此資源');
+      // }
+
+      // 調用 Service 更新金幣儲值包
+      const coinPack = await this.coinPacksService.updateCoinPackAdmin(
+        id,
+        updateCoinPackAdminDto,
+      );
+
+      // 資料轉換 (Decimal → Number)
+      const response: UpdateCoinPackAdminResponseDto = {
+        success: true,
+        message: 'Updated successfully',
+        data: {
+          id: coinPack.id,
+          platform: coinPack.platform as 'GOOGLE' | 'APPLE',
+          productId: coinPack.productId,
+          name: coinPack.name,
+          amount: coinPack.amount,
+          bonusAmount: coinPack.bonusAmount,
+          price: Number(coinPack.price),
+          currency: coinPack.currency,
+          isActive: coinPack.isActive,
+          sortOrder: coinPack.sortOrder,
+          createdAt: coinPack.createdAt,
+          updatedAt: coinPack.updatedAt,
+        },
+      };
+
+      return response;
+    } catch (error) {
+      // HttpException 已由 Service 層或 Guard 拋出，直接拋出
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
+      // 其他未預期的錯誤
+      throw new HttpException('更新金幣儲值包失敗', 500);
     }
   }
 }

--- a/src/iap/coin-packs.service.ts
+++ b/src/iap/coin-packs.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, BadRequestException, InternalServerErrorException, Logger } from '@nestjs/common';
+import { Injectable, BadRequestException, InternalServerErrorException, Logger, NotFoundException, HttpException } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { CreateCoinPackRequestDto } from './dto/create-coin-pack-request.dto';
+import { UpdateCoinPackAdminRequestDto } from './dto/update-coin-pack-admin-request.dto';
 
 @Injectable()
 export class CoinPacksService {
@@ -87,20 +88,109 @@ export class CoinPacksService {
 
       return coinPack;
     } catch (error) {
-      // P2002 是 Prisma 的唯一約束違反錯誤代碼
-      if (error.code === 'P2002') {
-        this.logger.warn(`Unique constraint violation: ${error.message}`);
-        throw new BadRequestException('此 platform 與 productId 的組合已存在');
-      }
-
-      // 如果已經是 HttpException，直接拋出
-      if (error.status) {
+      // 檢查 error 是否為 HttpException
+      if (error instanceof HttpException) {
         throw error;
       }
 
+      // 確認錯誤類型，用於檢查 Prisma 特定錯誤
+      const prismaError = error as Record<string, unknown>;
+
+      // P2002 是 Prisma 的唯一約束違反錯誤代碼
+      if (prismaError.code === 'P2002') {
+        this.logger.warn(`Unique constraint violation: ${String(prismaError.message)}`);
+        throw new BadRequestException('此 platform 與 productId 的組合已存在');
+      }
+
       // 其他未預期的錯誤
-      this.logger.error(`Failed to create coin pack: ${error.message}`, error.stack);
+      const errorMessage = prismaError.message ? String(prismaError.message) : '未知錯誤';
+      this.logger.error(`Failed to create coin pack: ${errorMessage}`, error instanceof Error ? error.stack : '');
       throw new InternalServerErrorException('建立金幣儲值包失敗，請稍後重試');
+    }
+  }
+
+  /**
+   * 更新金幣儲值包 (Admin Only) - 用於上下架管理
+   * @param id 金幣儲值包 ID
+   * @param updateCoinPackAdminDto 更新資料 (platform, product_id, name, is_active)
+   * @returns 更新後的金幣儲值包
+   * @throws NotFoundException - 當指定 ID 的金幣儲值包不存在
+   * @throws BadRequestException - 當參數不合法或唯一性約束違反
+   * @throws InternalServerErrorException - 資料庫操作失敗
+   */
+  async updateCoinPackAdmin(id: number, updateCoinPackAdminDto: UpdateCoinPackAdminRequestDto) {
+    try {
+      // 1. 檢查金幣儲值包是否存在
+      const existingPack = await this.prisma.coinPack.findUnique({
+        where: { id },
+      });
+
+      if (!existingPack) {
+        this.logger.warn(`Attempt to update non-existent coin pack: id=${id}`);
+        throw new NotFoundException(`金幣儲值包不存在 (ID: ${id})`);
+      }
+
+      // 2. 如果更新 platform 或 product_id，檢查新組合是否已存在
+      if (
+        existingPack.platform !== updateCoinPackAdminDto.platform ||
+        existingPack.productId !== updateCoinPackAdminDto.product_id
+      ) {
+        const duplicatePack = await this.prisma.coinPack.findUnique({
+          where: {
+            platform_productId: {
+              platform: updateCoinPackAdminDto.platform,
+              productId: updateCoinPackAdminDto.product_id,
+            },
+          },
+        });
+
+        if (duplicatePack) {
+          this.logger.warn(
+            `Duplicate coin pack attempt during update: platform=${updateCoinPackAdminDto.platform}, productId=${updateCoinPackAdminDto.product_id}`,
+          );
+          throw new BadRequestException(
+            `此 platform (${updateCoinPackAdminDto.platform}) 已存在相同的 productId (${updateCoinPackAdminDto.product_id})`,
+          );
+        }
+      }
+
+      // 3. 執行更新操作
+      const updatedPack = await this.prisma.coinPack.update({
+        where: { id },
+        data: {
+          platform: updateCoinPackAdminDto.platform,
+          productId: updateCoinPackAdminDto.product_id,
+          name: updateCoinPackAdminDto.name,
+          // 將 is_active (0|1) 轉換為 isActive (boolean)
+          // 0 表示下架 (false), 1 表示上架 (true)
+          isActive: updateCoinPackAdminDto.is_active === 0 ? false : true,
+        },
+      });
+
+      this.logger.log(
+        `Successfully updated coin pack: id=${updatedPack.id}, isActive=${updatedPack.isActive}`,
+      );
+
+      return updatedPack;
+    } catch (error) {
+      // 檢查 error 是否為 HttpException
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
+      // 確認錯誤類型，用於檢查 Prisma 特定錯誤
+      const prismaError = error as Record<string, unknown>;
+
+      // P2002 是 Prisma 的唯一約束違反錯誤代碼
+      if (prismaError.code === 'P2002') {
+        this.logger.warn(`Unique constraint violation during update: ${String(prismaError.message)}`);
+        throw new BadRequestException('此 platform 與 productId 的組合已存在');
+      }
+
+      // 其他未預期的錯誤
+      const errorMessage = prismaError.message ? String(prismaError.message) : '未知錯誤';
+      this.logger.error(`Failed to update coin pack: ${errorMessage}`, error instanceof Error ? error.stack : '');
+      throw new InternalServerErrorException('更新金幣儲值包失敗，請稍後重試');
     }
   }
 }

--- a/src/iap/dto/update-coin-pack-admin-request.dto.ts
+++ b/src/iap/dto/update-coin-pack-admin-request.dto.ts
@@ -1,0 +1,75 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  MinLength,
+  MaxLength,
+  IsEnum,
+  IsInt,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * @description 管理員更新金幣儲值包的請求 DTO
+ * 用於上下架金幣商品，支援更新 platform, product_id, name, is_active 等欄位
+ */
+export class UpdateCoinPackAdminRequestDto {
+  /**
+   * @description 平台類型 (GOOGLE 或 APPLE)
+   * @example GOOGLE
+   */
+  @ApiProperty({
+    description: '平台類型',
+    enum: ['GOOGLE', 'APPLE'],
+    example: 'GOOGLE',
+  })
+  @IsNotEmpty({ message: '平台類型不能為空' })
+  @IsEnum(['GOOGLE', 'APPLE'], { message: '平台類型只能為 GOOGLE 或 APPLE' })
+  @IsString({ message: '平台類型必須為字串' })
+  @MinLength(2, { message: '平台類型長度不能少於 2 個字元' })
+  @MaxLength(20, { message: '平台類型長度不能超過 20 個字元' })
+  platform: 'GOOGLE' | 'APPLE';
+
+  /**
+   * @description 商品 ID (SKU)
+   * @example test_item_001
+   */
+  @ApiProperty({
+    description: '商品 ID (SKU)，用於區分不同商品',
+    example: 'test_item_001',
+  })
+  @IsNotEmpty({ message: '商品 ID 不能為空' })
+  @IsString({ message: '商品 ID 必須為字串' })
+  @MinLength(2, { message: '商品 ID 長度不能少於 2 個字元' })
+  @MaxLength(100, { message: '商品 ID 長度不能超過 100 個字元' })
+  product_id: string;
+
+  /**
+   * @description 商品名稱
+   * @example 90 金幣 + 5 Bonus
+   */
+  @ApiProperty({
+    description: '商品名稱，用於顯示給用戶',
+    example: '90 金幣 + 5 Bonus',
+  })
+  @IsNotEmpty({ message: '商品名稱不能為空' })
+  @IsString({ message: '商品名稱必須為字串' })
+  @MinLength(2, { message: '商品名稱長度不能少於 2 個字元' })
+  @MaxLength(100, { message: '商品名稱長度不能超過 100 個字元' })
+  name: string;
+
+  /**
+   * @description 是否上架 (必填，1 = 上架, 0 = 下架)
+   * @example 1
+   */
+  @ApiProperty({
+    description: '是否上架 (1: 上架, 0: 下架)',
+    example: 1,
+    enum: [0, 1],
+  })
+  @IsNotEmpty({ message: 'is_active 不能為空' })
+  @Type(() => Number)
+  @IsInt({ message: 'is_active 必須為整數' })
+  @IsEnum([0, 1], { message: 'is_active 只能為 0 或 1' })
+  is_active: number;
+}

--- a/src/iap/dto/update-coin-pack-admin-response.dto.ts
+++ b/src/iap/dto/update-coin-pack-admin-response.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * @description 管理員更新金幣儲值包的回應 DTO
+ */
+export class UpdateCoinPackAdminResponseDto {
+  /**
+   * @description 請求是否成功
+   * @example true
+   */
+  @ApiProperty({
+    description: '請求是否成功',
+    example: true,
+  })
+  success: boolean;
+
+  /**
+   * @description 操作訊息
+   * @example Updated successfully
+   */
+  @ApiProperty({
+    description: '操作訊息',
+    example: 'Updated successfully',
+  })
+  message: string;
+
+  /**
+   * @description 更新後的金幣儲值包資料
+   */
+  @ApiProperty({
+    description: '更新後的金幣儲值包資料',
+    type: 'object',
+    properties: {
+      id: { type: 'number', example: 1 },
+      platform: { type: 'string', enum: ['GOOGLE', 'APPLE'], example: 'GOOGLE' },
+      productId: { type: 'string', example: 'com.example.coins.100' },
+      name: { type: 'string', example: '90 金幣 + 5 Bonus' },
+      amount: { type: 'number', example: 90 },
+      bonusAmount: { type: 'number', example: 5 },
+      price: { type: 'number', example: 90.99 },
+      currency: { type: 'string', example: 'TWD' },
+      isActive: { type: 'boolean', example: true },
+      sortOrder: { type: 'number', example: 999 },
+      createdAt: { type: 'string', format: 'date-time' },
+      updatedAt: { type: 'string', format: 'date-time' },
+    },
+  })
+  data: {
+    id: number;
+    platform: 'GOOGLE' | 'APPLE';
+    productId: string;
+    name: string;
+    amount: number;
+    bonusAmount: number;
+    price: number;
+    currency: string;
+    isActive: boolean;
+    sortOrder: number;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Auth API')
     .setDescription('烏努努小說平台後端 API 文件')
-    .setVersion('1.9.3')
+    .setVersion('1.9.4')
     .addBearerAuth()
     .build();
 


### PR DESCRIPTION
- 將 API 版本號從 1.9.3 更新至 1.9.4
- 在 `coin-packs.controller.ts` 中新增 `PATCH /coin-packs/:id` 端點，允許管理員更新金幣儲值包的 platform、product_id、name 和 is_active（上下架狀態）。

1. **Endpoint**: `PATH /api/admin/coin-packs`
2. **功能**: 後台上下架指定金幣商品。
2. **權限控制**: 
   - 需套用 `AdminGuard` 與 `Roles` Decorator。
   - 檢查邏輯：`req.user.roleLevel >= 9`（請在代碼中以註釋標註此邏輯）。

3. **參數驗證 (DTO)**: 
   - `platform`: 必填,字串，長度 2-20 字
   - `product_id`: 必填,字串，長度 2-100 字
   - `name`: 必填，字串，長度 2-100 字。
   - `is_`: 必填,int，只接受 '0' 跟 '1'。

4. **資料返回 (Response Structure)**: 
   - 成功 (200 Created): 回傳 `{ success: true, message: 'Created successfully', data: { id, ... } }`。
   - 驗證失敗 (400 Bad Request): 包含錯誤欄位訊息。
   - 權限不足 (403 Forbidden): 回傳權限錯誤提示。

