### PR TITLE
feat(admin): 更新金幣儲值包上下架狀態的 API 及相關 DTO

### DIFF
--- a/src/iap/coin-packs.controller.ts
+++ b/src/iap/coin-packs.controller.ts
@@ -169,8 +169,8 @@ export class CoinPacksController {
   }
 
   /**
-   * 更新金幣儲值包 (Admin Only) - 用於上下架管理
-   * @description 管理員可透過此端點更新金幣商品的 platform、product_id、name 和 is_active（上下架狀態）
+   * 更新金幣儲值包上下架狀態 (Admin Only)
+   * @description 管理員可透過此端點上下架指定的金幣商品
    * @requires JWT Token + Admin 權限 (roleLevel >= 9)
    */
   @Patch(':id')
@@ -183,19 +183,19 @@ export class CoinPacksController {
     example: 1,
   })
   @ApiOperation({
-    summary: '更新金幣儲值包 (管理員專用)',
-    description: '更新既有的金幣儲值包商品，支援更改 platform、product_id、name 和上下架狀態 (is_active)。需要 JWT Token 且用戶 roleLevel >= 9 (Admin)。',
+    summary: '上下架金幣商品 (管理員專用)',
+    description: '更新指定金幣商品的上下架狀態。需要 JWT Token 且用戶 roleLevel >= 9 (Admin)。',
   })
   @ApiOkResponse({
-    description: '成功更新金幣儲值包',
+    description: '成功更新金幣商品上下架狀態',
     type: UpdateCoinPackAdminResponseDto,
   })
   @ApiBadRequestResponse({
-    description: '參數驗證失敗或重複的 platform + productId 組合',
+    description: '參數驗證失敗 (is_active 必須為 0 或 1)',
     schema: {
       example: {
         statusCode: 400,
-        message: '此 platform 與 productId 的組合已存在',
+        message: 'validation failed: is_active 只能為 0 或 1',
         error: 'Bad Request',
       },
     },
@@ -211,7 +211,7 @@ export class CoinPacksController {
     },
   })
   @ApiNotFoundResponse({
-    description: '指定 ID 的金幣儲值包不存在',
+    description: '指定 ID 的金幣商品不存在',
     schema: {
       example: {
         statusCode: 404,
@@ -232,7 +232,7 @@ export class CoinPacksController {
       //   throw new ForbiddenException('只有管理員可存取此資源');
       // }
 
-      // 調用 Service 更新金幣儲值包
+      // 調用 Service 更新金幣商品上下架狀態
       const coinPack = await this.coinPacksService.updateCoinPackAdmin(
         id,
         updateCoinPackAdminDto,
@@ -266,7 +266,7 @@ export class CoinPacksController {
       }
 
       // 其他未預期的錯誤
-      throw new HttpException('更新金幣儲值包失敗', 500);
+      throw new HttpException('更新金幣商品上下架狀態失敗', 500);
     }
   }
 }

--- a/src/iap/coin-packs.service.ts
+++ b/src/iap/coin-packs.service.ts
@@ -110,12 +110,11 @@ export class CoinPacksService {
   }
 
   /**
-   * 更新金幣儲值包 (Admin Only) - 用於上下架管理
+   * 更新金幣儲值包上下架狀態 (Admin Only)
    * @param id 金幣儲值包 ID
-   * @param updateCoinPackAdminDto 更新資料 (platform, product_id, name, is_active)
+   * @param updateCoinPackAdminDto 只包含 is_active 欄位的DTO
    * @returns 更新後的金幣儲值包
    * @throws NotFoundException - 當指定 ID 的金幣儲值包不存在
-   * @throws BadRequestException - 當參數不合法或唯一性約束違反
    * @throws InternalServerErrorException - 資料庫操作失敗
    */
   async updateCoinPackAdmin(id: number, updateCoinPackAdminDto: UpdateCoinPackAdminRequestDto) {
@@ -130,45 +129,18 @@ export class CoinPacksService {
         throw new NotFoundException(`金幣儲值包不存在 (ID: ${id})`);
       }
 
-      // 2. 如果更新 platform 或 product_id，檢查新組合是否已存在
-      if (
-        existingPack.platform !== updateCoinPackAdminDto.platform ||
-        existingPack.productId !== updateCoinPackAdminDto.product_id
-      ) {
-        const duplicatePack = await this.prisma.coinPack.findUnique({
-          where: {
-            platform_productId: {
-              platform: updateCoinPackAdminDto.platform,
-              productId: updateCoinPackAdminDto.product_id,
-            },
-          },
-        });
-
-        if (duplicatePack) {
-          this.logger.warn(
-            `Duplicate coin pack attempt during update: platform=${updateCoinPackAdminDto.platform}, productId=${updateCoinPackAdminDto.product_id}`,
-          );
-          throw new BadRequestException(
-            `此 platform (${updateCoinPackAdminDto.platform}) 已存在相同的 productId (${updateCoinPackAdminDto.product_id})`,
-          );
-        }
-      }
-
-      // 3. 執行更新操作
+      // 2. 只更新 isActive 欄位
+      // 將 is_active (0|1) 轉換為 isActive (boolean)
+      // 0 表示下架 (false), 1 表示上架 (true)
       const updatedPack = await this.prisma.coinPack.update({
         where: { id },
         data: {
-          platform: updateCoinPackAdminDto.platform,
-          productId: updateCoinPackAdminDto.product_id,
-          name: updateCoinPackAdminDto.name,
-          // 將 is_active (0|1) 轉換為 isActive (boolean)
-          // 0 表示下架 (false), 1 表示上架 (true)
           isActive: updateCoinPackAdminDto.is_active === 0 ? false : true,
         },
       });
 
       this.logger.log(
-        `Successfully updated coin pack: id=${updatedPack.id}, isActive=${updatedPack.isActive}`,
+        `Successfully updated coin pack status: id=${updatedPack.id}, isActive=${updatedPack.isActive}`,
       );
 
       return updatedPack;
@@ -178,19 +150,10 @@ export class CoinPacksService {
         throw error;
       }
 
-      // 確認錯誤類型，用於檢查 Prisma 特定錯誤
-      const prismaError = error as Record<string, unknown>;
-
-      // P2002 是 Prisma 的唯一約束違反錯誤代碼
-      if (prismaError.code === 'P2002') {
-        this.logger.warn(`Unique constraint violation during update: ${String(prismaError.message)}`);
-        throw new BadRequestException('此 platform 與 productId 的組合已存在');
-      }
-
       // 其他未預期的錯誤
-      const errorMessage = prismaError.message ? String(prismaError.message) : '未知錯誤';
-      this.logger.error(`Failed to update coin pack: ${errorMessage}`, error instanceof Error ? error.stack : '');
-      throw new InternalServerErrorException('更新金幣儲值包失敗，請稍後重試');
+      const errorMessage = error instanceof Error ? error.message : '未知錯誤';
+      this.logger.error(`Failed to update coin pack status: ${errorMessage}`, error instanceof Error ? error.stack : '');
+      throw new InternalServerErrorException('更新金幣儲值包上下架狀態失敗，請稍後重試');
     }
   }
 }

--- a/src/iap/dto/update-coin-pack-admin-request.dto.ts
+++ b/src/iap/dto/update-coin-pack-admin-request.dto.ts
@@ -1,63 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  IsString,
   IsNotEmpty,
-  MinLength,
-  MaxLength,
-  IsEnum,
   IsInt,
+  IsEnum,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
 /**
- * @description 管理員更新金幣儲值包的請求 DTO
- * 用於上下架金幣商品，支援更新 platform, product_id, name, is_active 等欄位
+ * @description 管理員更新金幣儲值包上下架狀態的請求 DTO
+ * 用於上下架指定金幣商品
  */
 export class UpdateCoinPackAdminRequestDto {
-  /**
-   * @description 平台類型 (GOOGLE 或 APPLE)
-   * @example GOOGLE
-   */
-  @ApiProperty({
-    description: '平台類型',
-    enum: ['GOOGLE', 'APPLE'],
-    example: 'GOOGLE',
-  })
-  @IsNotEmpty({ message: '平台類型不能為空' })
-  @IsEnum(['GOOGLE', 'APPLE'], { message: '平台類型只能為 GOOGLE 或 APPLE' })
-  @IsString({ message: '平台類型必須為字串' })
-  @MinLength(2, { message: '平台類型長度不能少於 2 個字元' })
-  @MaxLength(20, { message: '平台類型長度不能超過 20 個字元' })
-  platform: 'GOOGLE' | 'APPLE';
-
-  /**
-   * @description 商品 ID (SKU)
-   * @example test_item_001
-   */
-  @ApiProperty({
-    description: '商品 ID (SKU)，用於區分不同商品',
-    example: 'test_item_001',
-  })
-  @IsNotEmpty({ message: '商品 ID 不能為空' })
-  @IsString({ message: '商品 ID 必須為字串' })
-  @MinLength(2, { message: '商品 ID 長度不能少於 2 個字元' })
-  @MaxLength(100, { message: '商品 ID 長度不能超過 100 個字元' })
-  product_id: string;
-
-  /**
-   * @description 商品名稱
-   * @example 90 金幣 + 5 Bonus
-   */
-  @ApiProperty({
-    description: '商品名稱，用於顯示給用戶',
-    example: '90 金幣 + 5 Bonus',
-  })
-  @IsNotEmpty({ message: '商品名稱不能為空' })
-  @IsString({ message: '商品名稱必須為字串' })
-  @MinLength(2, { message: '商品名稱長度不能少於 2 個字元' })
-  @MaxLength(100, { message: '商品名稱長度不能超過 100 個字元' })
-  name: string;
-
   /**
    * @description 是否上架 (必填，1 = 上架, 0 = 下架)
    * @example 1

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Auth API')
     .setDescription('烏努努小說平台後端 API 文件')
-    .setVersion('1.9.4')
+    .setVersion('1.9.5')
     .addBearerAuth()
     .build();
 


### PR DESCRIPTION
將 API 版本號從 1.9.4 更新至 1.9.5
- 更新 `UpdateCoinPackAdminRequestDto`，移除 platform、product_id、name 欄位，只保留 is_active 用於上下架狀態更新
- 修改 `CoinPacksService.updateCoinPackAdmin` 方法，僅更新 isActive 欄位，並調整錯誤處理邏輯
- 修改 `CoinPacksController` 的 PATCH 端點，更新 API 文件說明，強調此端點僅用於更新金幣商品的上下架狀態，並調整相關的 API 文件描述和錯誤回應說明