### PR TITLE
feat(admin): 新增管理員移除使用者對已購買書籍的擁有權功能

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Patch, Body, Param, UseGuards, HttpCode, HttpStatus, Logger, ParseIntPipe } from '@nestjs/common';
+import { Controller, Post, Patch, Delete, Body, Param, UseGuards, HttpCode, HttpStatus, Logger, ParseIntPipe } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBody, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { AdminService } from './admin.service';
 import { AdminGuard } from '../auth/admin.guard';
@@ -8,6 +8,7 @@ import { GrantRewardRequestDto } from './dto/grant-reward-request.dto';
 import { GrantRewardResponseDto } from './dto/grant-reward-response.dto';
 import { UpdateCoinLedgerRemarkDto } from './dto/update-coin-ledger-remark.dto';
 import { UpdateCoinPackNameDto } from './dto/update-coin-pack-name.dto';
+import { RemoveUserEntitlementResponseDto } from './dto/remove-user-entitlement-response.dto';
 
 @ApiTags('Admin')
 @ApiBearerAuth()
@@ -373,5 +374,94 @@ export class AdminController {
     );
 
     return this.adminService.updateCoinPackName(id, body, user.userId);
+  }
+
+  @Delete('users/:userId/entitlements/:bookId')
+  @UseGuards(JwtAuthGuard, AdminGuard) // ✅ 先 JWT 認證，再 Admin 授權
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '【管理員專用】移除使用者對已購買書籍的擁有權',
+    description: `
+      管理員可透過此 API 移除（或撤銷）指定使用者對某本已購買書籍的擁有權。
+      
+      **核心特性**：
+      - 需要 roleLevel >= 9 的管理員權限
+      - 執行硬刪除操作，此操作不可逆
+      - 檢查使用者是否擁有該書籍的權限紀錄，不存在返回 404 錯誤
+      - 所有操作均記錄於審計日誌
+      
+      **用途**：收回贈送的書籍、撤銷誤操作、權限管理等
+    `,
+  })
+  @ApiParam({
+    name: 'userId',
+    description: '使用者 ID',
+    type: Number,
+    example: 123,
+  })
+  @ApiParam({
+    name: 'bookId',
+    description: '書籍 ID（story_list_id）',
+    type: Number,
+    example: 456,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '擁有權移除成功',
+    type: RemoveUserEntitlementResponseDto,
+    example: {
+      success: true,
+      message: '已成功移除使用者 (ID: 123) 對書籍 (ID: 456) 的擁有權',
+      userId: 123,
+      bookId: 456,
+      removedAt: '2026-05-15T12:34:56.000Z',
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: '憑證無效或未登入',
+    example: {
+      statusCode: 401,
+      message: '未認證的使用者',
+      error: 'Unauthorized',
+    },
+  })
+  @ApiResponse({
+    status: 403,
+    description: '權限不足（非管理員，roleLevel < 9）',
+    example: {
+      statusCode: 403,
+      message: '只有管理員可存取此資源',
+      error: 'Forbidden',
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: '擁有權紀錄不存在',
+    example: {
+      statusCode: 404,
+      message: '使用者 (ID: 123) 不擁有書籍 (ID: 456) 的權限紀錄',
+      error: 'Not Found',
+    },
+  })
+  @ApiResponse({
+    status: 500,
+    description: '伺服器內部錯誤',
+    example: {
+      statusCode: 500,
+      message: '移除擁有權失敗: [錯誤詳情]',
+      error: 'Internal Server Error',
+    },
+  })
+  async removeUserEntitlement(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Param('bookId', ParseIntPipe) bookId: number,
+    @CurrentUser() user: any,
+  ): Promise<RemoveUserEntitlementResponseDto> {
+    this.logger.log(
+      `[RemoveEntitlement] 管理員 ${user.userId} 發起移除擁有權操作 | targetUserId=${userId}, bookId=${bookId}`,
+    );
+
+    return this.adminService.removeUserEntitlement(userId, bookId, user.userId);
   }
 }

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -233,4 +233,72 @@ export class AdminService {
       throw new BadRequestException(`金幣方案名稱更新失敗: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
+
+  /**
+   * 管理員移除指定使用者對某本已購買書籍的擁有權
+   * 此操作將硬刪除該擁有權記錄，不可逆。
+   *
+   * @param userId 使用者 ID
+   * @param bookId 書籍 ID（story_list_id）
+   * @param adminId 執行此操作的管理員 ID（用於審計日誌）
+   * @returns 移除結果
+   * @throws NotFoundException 如果擁有權紀錄不存在
+   */
+  async removeUserEntitlement(
+    userId: number,
+    bookId: number,
+    adminId: number,
+  ): Promise<{
+    success: boolean;
+    message: string;
+    userId: number;
+    bookId: number;
+    removedAt: string;
+  }> {
+    // ✅ Step 1: 檢查該使用者是否確實擁有該書籍的權限紀錄
+    const entitlement = await this.prisma.entitlements.findFirst({
+      where: {
+        user_id: BigInt(userId),
+        story_list_id: bookId,
+      },
+    });
+
+    if (!entitlement) {
+      this.logger.warn(
+        `[RemoveEntitlement] 嘗試移除不存在的擁有權紀錄: userId=${userId}, bookId=${bookId}, admin=${adminId}`,
+      );
+      throw new NotFoundException(
+        `使用者 (ID: ${userId}) 不擁有書籍 (ID: ${bookId}) 的權限紀錄`,
+      );
+    }
+
+    // ✅ Step 2: 執行硬刪除操作
+    try {
+      await this.prisma.entitlements.deleteMany({
+        where: {
+          user_id: BigInt(userId),
+          story_list_id: bookId,
+        },
+      });
+
+      this.logger.log(
+        `[RemoveEntitlement] 成功移除 | admin=${adminId}, userId=${userId}, bookId=${bookId}`,
+      );
+
+      return {
+        success: true,
+        message: `已成功移除使用者 (ID: ${userId}) 對書籍 (ID: ${bookId}) 的擁有權`,
+        userId,
+        bookId,
+        removedAt: new Date().toISOString(),
+      };
+    } catch (error) {
+      this.logger.error(
+        `[RemoveEntitlement] 刪除失敗 | admin=${adminId}, userId=${userId}, bookId=${bookId}, error=${error instanceof Error ? error.message : String(error)}`,
+      );
+      throw new BadRequestException(
+        `移除擁有權失敗: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
 }

--- a/src/admin/dto/remove-user-entitlement-response.dto.ts
+++ b/src/admin/dto/remove-user-entitlement-response.dto.ts
@@ -1,0 +1,10 @@
+/**
+ * 移除使用者書籍擁有權的回應 DTO
+ */
+export class RemoveUserEntitlementResponseDto {
+  success: boolean;
+  message: string;
+  userId: number;
+  bookId: number;
+  removedAt: string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Auth API')
     .setDescription('烏努努小說平台後端 API 文件')
-    .setVersion('1.9.8')
+    .setVersion('1.9.9')
     .addBearerAuth()
     .build();
 


### PR DESCRIPTION
- 更新 main.ts 中的 API 版本號至 1.9.9。
- 在 admin.service.ts 中新增 removeUserEntitlement 方法，實現管理員移除使用者對已購買書籍的擁有權功能，包含檢查擁有權紀錄、執行硬刪除、錯誤處理和審計日誌記錄。
- 在 admin.controller.ts 中新增對應的 DELETE API 端點，使用 JwtAuthGuard 和 AdminGuard 進行安全保護，並使用 Swagger 補充 API 文件說明和範例。
- 新增 remove-user-entitlement-response.dto.ts 定義 API 回應的資料結構。
- 此功能允許管理員收回贈送的書籍、撤銷誤操作或進行權限管理，並且所有操作均記錄於審計日誌以供追蹤。
- 注意：此操作將硬刪除擁有權紀錄，不可逆，請謹慎使用。
- 相關 API 文件已更新，請參考 Swagger UI 獲取詳細資訊。