### PR TITLE
feat(admin): 新增管理員標記 IAP 收據狀態為退款的功能

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -9,6 +9,12 @@ import { GrantRewardResponseDto } from './dto/grant-reward-response.dto';
 import { UpdateCoinLedgerRemarkDto } from './dto/update-coin-ledger-remark.dto';
 import { UpdateCoinPackNameDto } from './dto/update-coin-pack-name.dto';
 import { RemoveUserEntitlementResponseDto } from './dto/remove-user-entitlement-response.dto';
+import {
+  IapReceiptStatus,
+  UpdateIapReceiptStatusDto,
+  UpdateIapReceiptStatusParamDto,
+  UpdateIapReceiptStatusResponseDto,
+} from './dto/update-iap-receipt-status.dto';
 
 @ApiTags('Admin')
 @ApiBearerAuth()
@@ -133,6 +139,103 @@ export class AdminController {
     );
 
     return this.adminService.grantRewardToUser(body, user.userId);
+  }
+
+  @Patch('iap-receipts/:id/status')
+  @UseGuards(JwtAuthGuard, AdminGuard) // ✅ 先 JWT 認證，再 Admin 授權
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '【管理員專用】將 IAP 收據狀態標記為退款',
+    description: `
+      管理員可透過此 API 將指定 IAP 收據從 SUCCESS 標記為 REFUNDED。
+      
+      **核心特性**：
+      - 需要 roleLevel >= 9 的管理員權限
+      - 僅允許將 SUCCESS 交易標記為 REFUNDED
+      - 若收據不存在回傳 404
+      - 若收據不是 SUCCESS 狀態，回傳 400，避免重複退款或錯誤狀態轉換
+    `,
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'IAP 收據 ID（iap_receipts.id）',
+    type: Number,
+    example: 123,
+  })
+  @ApiBody({
+    type: UpdateIapReceiptStatusDto,
+    examples: {
+      refunded: {
+        summary: '標記退款',
+        value: {
+          status: IapReceiptStatus.REFUNDED,
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'IAP 收據狀態更新成功',
+    type: UpdateIapReceiptStatusResponseDto,
+    example: {
+      success: true,
+      id: 123,
+      userId: 456,
+      platform: 'GOOGLE',
+      productId: 'coins_100',
+      transactionId: 'GPA.3218-2019-1234567890',
+      coins: 110,
+      status: 'REFUNDED',
+      createdAt: '2026-05-15T10:30:00.000Z',
+      markedAt: '2026-05-25T12:34:56.000Z',
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: '請求參數驗證失敗，或收據目前狀態不可退款',
+    example: {
+      statusCode: 400,
+      message: '僅能針對成功交易進行退款標記',
+      error: 'Bad Request',
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: '憑證無效或未登入',
+    example: {
+      statusCode: 401,
+      message: '未認證的使用者',
+      error: 'Unauthorized',
+    },
+  })
+  @ApiResponse({
+    status: 403,
+    description: '權限不足（非管理員，roleLevel < 9）',
+    example: {
+      statusCode: 403,
+      message: '只有管理員可存取此資源',
+      error: 'Forbidden',
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'IAP 收據不存在',
+    example: {
+      statusCode: 404,
+      message: 'IAP 收據 (ID: 999999) 不存在',
+      error: 'Not Found',
+    },
+  })
+  async updateIapReceiptStatus(
+    @Param() params: UpdateIapReceiptStatusParamDto,
+    @Body() body: UpdateIapReceiptStatusDto,
+    @CurrentUser() user: any,
+  ): Promise<UpdateIapReceiptStatusResponseDto> {
+    this.logger.log(
+      `[UpdateIapReceiptStatus] 管理員 ${user.userId} 發起退款標記操作 | iapReceiptId=${params.id}, status=${body.status}`,
+    );
+
+    return this.adminService.updateIapReceiptStatus(params.id, body, user.userId);
   }
 
   @Patch('coin-ledger/:id/remark')

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -4,6 +4,11 @@ import { GrantRewardRequestDto } from './dto/grant-reward-request.dto';
 import { GrantRewardResponseDto } from './dto/grant-reward-response.dto';
 import { UpdateCoinLedgerRemarkDto } from './dto/update-coin-ledger-remark.dto';
 import { UpdateCoinPackNameDto } from './dto/update-coin-pack-name.dto';
+import {
+  IapReceiptStatus,
+  UpdateIapReceiptStatusDto,
+  UpdateIapReceiptStatusResponseDto,
+} from './dto/update-iap-receipt-status.dto';
 
 @Injectable()
 export class AdminService {
@@ -90,6 +95,82 @@ export class AdminService {
       );
       throw new BadRequestException(`金幣發放失敗: ${error instanceof Error ? error.message : String(error)}`);
     }
+  }
+
+  /**
+   * 管理員將成功的 IAP 收據標記為退款
+   *
+   * @param iapReceiptId IAP 收據 ID
+   * @param updateDto 更新請求（status 僅允許 REFUNDED）
+   * @param adminId 執行此操作的管理員 ID（用於審計日誌）
+   * @returns 更新後的 IAP 收據資訊
+   * @throws NotFoundException 如果指定的 IAP 收據不存在
+   * @throws BadRequestException 如果收據目前不是 SUCCESS 狀態
+   */
+  async updateIapReceiptStatus(
+    iapReceiptId: number,
+    updateDto: UpdateIapReceiptStatusDto,
+    adminId: number,
+  ): Promise<UpdateIapReceiptStatusResponseDto> {
+    const result = await this.prisma.$transaction(async (tx) => {
+      const receipt = await tx.iapReceipt.findUnique({
+        where: { id: iapReceiptId },
+      });
+
+      if (!receipt) {
+        this.logger.warn(
+          `[UpdateIapReceiptStatus] 嘗試更新不存在的 IAP 收據: id=${iapReceiptId}, admin=${adminId}`,
+        );
+        throw new NotFoundException(`IAP 收據 (ID: ${iapReceiptId}) 不存在`);
+      }
+
+      if (receipt.status !== 'SUCCESS') {
+        this.logger.warn(
+          `[UpdateIapReceiptStatus] 收據狀態不可退款 | id=${iapReceiptId}, currentStatus=${receipt.status}, admin=${adminId}`,
+        );
+        throw new BadRequestException('僅能針對成功交易進行退款標記');
+      }
+
+      const updateResult = await tx.iapReceipt.updateMany({
+        where: {
+          id: iapReceiptId,
+          status: 'SUCCESS',
+        },
+        data: {
+          status: updateDto.status,
+        },
+      });
+
+      if (updateResult.count !== 1) {
+        this.logger.warn(
+          `[UpdateIapReceiptStatus] 收據狀態已被異動，無法退款 | id=${iapReceiptId}, admin=${adminId}`,
+        );
+        throw new BadRequestException('僅能針對成功交易進行退款標記');
+      }
+
+      const updatedReceipt = await tx.iapReceipt.findUniqueOrThrow({
+        where: { id: iapReceiptId },
+      });
+
+      this.logger.log(
+        `[UpdateIapReceiptStatus] 成功更新 | admin=${adminId}, iapReceiptId=${iapReceiptId}, transactionId=${updatedReceipt.transactionId}, status=${updatedReceipt.status}`,
+      );
+
+      return updatedReceipt;
+    });
+
+    return {
+      success: true,
+      id: result.id,
+      userId: result.userId,
+      platform: result.platform,
+      productId: result.productId,
+      transactionId: result.transactionId,
+      coins: result.coins,
+      status: result.status as IapReceiptStatus,
+      createdAt: result.createdAt,
+      markedAt: new Date().toISOString(),
+    };
   }
 
   /**

--- a/src/admin/dto/update-iap-receipt-status.dto.ts
+++ b/src/admin/dto/update-iap-receipt-status.dto.ts
@@ -1,0 +1,77 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, Min } from 'class-validator';
+
+export enum IapReceiptStatus {
+  REFUNDED = 'REFUNDED',
+}
+
+export class UpdateIapReceiptStatusParamDto {
+  @ApiProperty({
+    description: 'IAP 收據 ID（iap_receipts.id）',
+    example: 123,
+    type: Number,
+  })
+  @Type(() => Number)
+  @IsInt({ message: 'id 必須是有效的整數' })
+  @Min(1, { message: 'id 必須是大於 0 的整數' })
+  id: number;
+}
+
+export class UpdateIapReceiptStatusDto {
+  @ApiProperty({
+    description: '欲更新的退款狀態，目前僅允許 REFUNDED',
+    enum: IapReceiptStatus,
+    example: IapReceiptStatus.REFUNDED,
+  })
+  @IsEnum(IapReceiptStatus, { message: 'status 僅允許 REFUNDED' })
+  status: IapReceiptStatus;
+}
+
+export class UpdateIapReceiptStatusResponseDto {
+  @ApiProperty({ example: true, description: '是否更新成功' })
+  success: boolean;
+
+  @ApiProperty({ example: 123, description: 'IAP 收據 ID' })
+  id: number;
+
+  @ApiProperty({ example: 456, description: '使用者 ID' })
+  userId: number;
+
+  @ApiProperty({ example: 'GOOGLE', description: 'IAP 平台' })
+  platform: string;
+
+  @ApiProperty({
+    example: 'coins_100',
+    description: 'IAP 商品 ID',
+  })
+  productId: string;
+
+  @ApiProperty({
+    example: 'GPA.3218-2019-1234567890',
+    description: '交易 ID / 收據 ID',
+  })
+  transactionId: string;
+
+  @ApiProperty({ example: 110, description: '本筆交易金幣數' })
+  coins: number;
+
+  @ApiProperty({
+    enum: IapReceiptStatus,
+    example: IapReceiptStatus.REFUNDED,
+    description: '更新後的收據狀態',
+  })
+  status: IapReceiptStatus;
+
+  @ApiProperty({
+    example: '2026-05-15T10:30:00.000Z',
+    description: '收據建立時間',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: '2026-05-25T12:34:56.000Z',
+    description: '退款標記完成時間',
+  })
+  markedAt: string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Auth API')
     .setDescription('烏努努小說平台後端 API 文件')
-    .setVersion('1.9.11')
+    .setVersion('1.9.12')
     .addBearerAuth()
     .build();
 


### PR DESCRIPTION
- 在 `AdminController` 中新增 PATCH `/admin/iap-receipts/:id/status` API，允許管理員將指定 IAP 收據從 SUCCESS 標記為 REFUNDED。
- 在 `AdminService` 中實作 `updateIapReceiptStatus` 方法，包含以下邏輯：
  - 驗證 IAP 收據是否存在，若不存在回傳 404。
  - 驗證收據目前是否為 SUCCESS 狀態，若不是回傳 400，避免重複退款或錯誤狀態轉換。
  - 使用資料庫交易確保狀態更新的原子性，避免競爭條件導致的狀態不一致。
  - 成功更新後回傳更新後的收據資訊，並在日誌中記錄操作細節以利審計。
- 更新 `main.ts` 中的 API 文件版本號至 1.9.12。