### PR TITLE
feat(admin): 新增後台取得完整金幣方案清單的 API 端點及相關 DTO

### DIFF
--- a/src/iap/coin-packs.controller.ts
+++ b/src/iap/coin-packs.controller.ts
@@ -23,9 +23,12 @@ import {
   ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiParam,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { GetCoinPacksRequestDto } from './dto/get-coin-packs-request.dto';
 import { GetCoinPacksResponseDto } from './dto/get-coin-packs-response.dto';
+import { GetCoinPacksQueryDto } from './dto/get-coin-packs-query.dto';
+import { GetAdminCoinPacksResponseDto } from './dto/get-admin-coin-packs-response.dto';
 import { CreateCoinPackRequestDto } from './dto/create-coin-pack-request.dto';
 import { CreateCoinPackResponseDto } from './dto/create-coin-pack-response.dto';
 import { UpdateCoinPackAdminRequestDto } from './dto/update-coin-pack-admin-request.dto';
@@ -35,11 +38,96 @@ import { AdminGuard } from '../auth/admin.guard';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 
 @ApiTags('IAP - Coin Packs')
-@Controller('coin-packs')
+@Controller()
 export class CoinPacksController {
   constructor(private readonly coinPacksService: CoinPacksService) {}
 
-  @Get()
+  @Get('admin/coin-packs')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: '【後台】取得完整金幣方案清單',
+    description: `
+      管理員可透過此 API 取得完整金幣方案商店清單。
+
+      **核心特性**：
+      - 需要 roleLevel >= 9 的管理員權限
+      - 支援 page / limit 分頁
+      - 預設依建立時間由新到舊排序
+      - 不過濾 is_active，包含啟用與停用方案
+    `,
+  })
+  @ApiQuery({
+    name: 'page',
+    description: '頁碼（可選，預設 1）',
+    type: Number,
+    example: 1,
+    required: false,
+  })
+  @ApiQuery({
+    name: 'limit',
+    description: '每頁筆數（可選，預設 20）',
+    type: Number,
+    example: 20,
+    required: false,
+  })
+  @ApiOkResponse({
+    description: '成功取得完整金幣方案清單',
+    type: GetAdminCoinPacksResponseDto,
+    example: {
+      success: true,
+      data: [
+        {
+          id: 2,
+          platform: 'APPLE',
+          product_id: 'com.xstory.coins_500',
+          name: '500 金幣',
+          amount: 500,
+          bonus_amount: 50,
+          price: 499,
+          currency: 'TWD',
+          is_active: false,
+          sort_order: 2,
+          created_at: '2026-05-15T10:30:00.000Z',
+          updated_at: '2026-05-15T12:34:56.000Z',
+        },
+        {
+          id: 1,
+          platform: 'GOOGLE',
+          product_id: 'coins_100',
+          name: '100 金幣',
+          amount: 100,
+          bonus_amount: 10,
+          price: 99,
+          currency: 'TWD',
+          is_active: true,
+          sort_order: 1,
+          created_at: '2026-05-14T10:30:00.000Z',
+          updated_at: '2026-05-14T10:30:00.000Z',
+        },
+      ],
+      total: 2,
+      page: 1,
+      limit: 20,
+    },
+  })
+  @ApiForbiddenResponse({
+    description: '權限不足 (需要 Admin 權限，roleLevel >= 9)',
+    schema: {
+      example: {
+        message: '只有管理員可存取此資源',
+        error: 'Forbidden',
+        statusCode: 403,
+      },
+    },
+  })
+  async findAllForAdmin(
+    @Query() query: GetCoinPacksQueryDto,
+  ): Promise<GetAdminCoinPacksResponseDto> {
+    return this.coinPacksService.findAllForAdmin(query);
+  }
+
+  @Get('coin-packs')
   @ApiOperation({ 
     summary: '取得金幣商品清單', 
     description: '取得目前資料庫中「上架中」且依序排列的金幣商品。' 
@@ -90,7 +178,7 @@ export class CoinPacksController {
    * @description 僅限管理員使用，用於建立新的金幣儲值包商品
    * @requires JWT Token + Admin 權限 (roleLevel >= 9)
    */
-  @Post()
+  @Post('coin-packs')
   @HttpCode(201)
   @UseGuards(JwtAuthGuard, AdminGuard)
   @ApiBearerAuth()
@@ -173,7 +261,7 @@ export class CoinPacksController {
    * @description 管理員可透過此端點上下架指定的金幣商品
    * @requires JWT Token + Admin 權限 (roleLevel >= 9)
    */
-  @Patch(':id')
+  @Patch('coin-packs/:id')
   @HttpCode(200)
   @UseGuards(JwtAuthGuard, AdminGuard)
   @ApiBearerAuth()

--- a/src/iap/coin-packs.service.ts
+++ b/src/iap/coin-packs.service.ts
@@ -2,6 +2,8 @@ import { Injectable, BadRequestException, InternalServerErrorException, Logger, 
 import { PrismaService } from '../prisma.service';
 import { CreateCoinPackRequestDto } from './dto/create-coin-pack-request.dto';
 import { UpdateCoinPackAdminRequestDto } from './dto/update-coin-pack-admin-request.dto';
+import { GetCoinPacksQueryDto } from './dto/get-coin-packs-query.dto';
+import { GetAdminCoinPacksResponseDto } from './dto/get-admin-coin-packs-response.dto';
 
 @Injectable()
 export class CoinPacksService {
@@ -37,6 +39,49 @@ export class CoinPacksService {
       //   platform: true,
       // }
     });
+  }
+
+  /**
+   * 後台取得完整金幣方案清單（不過濾上下架狀態）
+   */
+  async findAllForAdmin(
+    query: GetCoinPacksQueryDto,
+  ): Promise<GetAdminCoinPacksResponseDto> {
+    const page = query.page || 1;
+    const limit = query.limit || 20;
+    const skip = (page - 1) * limit;
+
+    const [total, coinPacks] = await this.prisma.$transaction([
+      this.prisma.coinPack.count(),
+      this.prisma.coinPack.findMany({
+        orderBy: {
+          createdAt: 'desc',
+        },
+        skip,
+        take: limit,
+      }),
+    ]);
+
+    return {
+      success: true,
+      data: coinPacks.map((pack) => ({
+        id: pack.id,
+        platform: pack.platform,
+        product_id: pack.productId,
+        name: pack.name,
+        amount: pack.amount,
+        bonus_amount: pack.bonusAmount,
+        price: Number(pack.price),
+        currency: pack.currency,
+        is_active: pack.isActive,
+        sort_order: pack.sortOrder,
+        created_at: pack.createdAt,
+        updated_at: pack.updatedAt,
+      })),
+      total,
+      page,
+      limit,
+    };
   }
 
   /**

--- a/src/iap/dto/get-admin-coin-packs-response.dto.ts
+++ b/src/iap/dto/get-admin-coin-packs-response.dto.ts
@@ -1,0 +1,56 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AdminCoinPackDto {
+  @ApiProperty({ description: '金幣方案 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '平台類型', example: 'GOOGLE' })
+  platform: string;
+
+  @ApiProperty({ description: '商品 ID', example: 'coins_100' })
+  product_id: string;
+
+  @ApiProperty({ description: '金幣方案名稱', example: '100 金幣' })
+  name: string;
+
+  @ApiProperty({ description: '基礎金幣數量', example: 100 })
+  amount: number;
+
+  @ApiProperty({ description: '贈送金幣數量', example: 10 })
+  bonus_amount: number;
+
+  @ApiProperty({ description: '價格', example: 99 })
+  price: number;
+
+  @ApiProperty({ description: '幣別', example: 'TWD' })
+  currency: string;
+
+  @ApiProperty({ description: '是否啟用', example: true })
+  is_active: boolean;
+
+  @ApiProperty({ description: '排序權重', example: 1 })
+  sort_order: number;
+
+  @ApiProperty({ description: '建立時間', example: '2026-05-15T10:30:00.000Z' })
+  created_at: Date;
+
+  @ApiProperty({ description: '更新時間', example: '2026-05-15T12:34:56.000Z' })
+  updated_at: Date;
+}
+
+export class GetAdminCoinPacksResponseDto {
+  @ApiProperty({ description: '請求是否成功', example: true })
+  success: boolean;
+
+  @ApiProperty({ type: [AdminCoinPackDto], description: '金幣方案列表' })
+  data: AdminCoinPackDto[];
+
+  @ApiProperty({ description: '總筆數', example: 42 })
+  total: number;
+
+  @ApiProperty({ description: '目前頁碼', example: 1 })
+  page: number;
+
+  @ApiProperty({ description: '每頁筆數', example: 20 })
+  limit: number;
+}

--- a/src/iap/dto/get-coin-packs-query.dto.ts
+++ b/src/iap/dto/get-coin-packs-query.dto.ts
@@ -1,0 +1,16 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class GetCoinPacksQueryDto {
+  @IsOptional()
+  @IsInt({ message: 'page 必須是整數' })
+  @Min(1, { message: 'page 必須大於等於 1' })
+  @Type(() => Number)
+  page?: number = 1;
+
+  @IsOptional()
+  @IsInt({ message: 'limit 必須是整數' })
+  @Min(1, { message: 'limit 必須大於等於 1' })
+  @Type(() => Number)
+  limit?: number = 20;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Auth API')
     .setDescription('烏努努小說平台後端 API 文件')
-    .setVersion('1.9.12')
+    .setVersion('1.9.13')
     .addBearerAuth()
     .build();
 


### PR DESCRIPTION
- 在 `coin-packs.controller.ts` 中新增 `GET /admin/coin-packs` 端點，供管理員取得完整金幣方案清單（包含上下架狀態）
- 在 `coin-packs.service.ts` 中新增 `findAllForAdmin` 方法，實作後台取得完整金幣方案清單的邏輯
- 新增 `get-coin-packs-query.dto.ts` 定義分頁查詢參數的 DTO
- 新增 `get-admin-coin-packs-response.dto.ts` 定義後台取得完整金幣方案清單的回應格式 DTO
- 更新 `main.ts` 中的 API 文件版本號至 1.9.13