### PR TITLE
feat(books): 新增書籍閱讀紀錄與統計功能

### DIFF
--- a/prisma/migrations/20260527000000_add_read_logs_and_book_analytics/migration.sql
+++ b/prisma/migrations/20260527000000_add_read_logs_and_book_analytics/migration.sql
@@ -1,0 +1,24 @@
+-- AlterTable
+ALTER TABLE `StoryLists`
+    ADD COLUMN `total_reads` INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN `unique_readers` INTEGER NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE `read_logs` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `user_id` INTEGER NOT NULL,
+    `book_id` INTEGER NOT NULL,
+    `created_at` DATETIME(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0),
+
+    INDEX `idx_read_logs_user_id`(`user_id`),
+    INDEX `idx_read_logs_book_id`(`book_id`),
+    INDEX `idx_read_logs_created_at`(`created_at`),
+    INDEX `idx_read_logs_user_book`(`user_id`, `book_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `read_logs` ADD CONSTRAINT `read_logs_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+-- AddForeignKey
+ALTER TABLE `read_logs` ADD CONSTRAINT `read_logs_book_id_fkey` FOREIGN KEY (`book_id`) REFERENCES `StoryLists`(`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   roleLevel     Int       @default(1) @map("role_level")
   createdAt     DateTime  @default(now()) @db.DateTime(0)
   updatedAt     DateTime  @default(now()) @updatedAt @db.DateTime(0)
+  readLogs      ReadLog[]
 }
 
 model StoryLists {
@@ -43,11 +44,29 @@ model StoryLists {
   open                  String?        @db.VarChar(255)
   view_times            String?        @db.VarChar(255)
   buy_times             String?        @db.VarChar(255)
+  totalReads            Int            @default(0) @map("total_reads")
+  uniqueReaders         Int            @default(0) @map("unique_readers")
   createdAt             DateTime       @db.DateTime(0)
   updatedAt             DateTime       @db.DateTime(0)
   storeItem             BookStoreItem?
+  readLogs              ReadLog[]
 
   @@map("StoryLists")
+}
+
+model ReadLog {
+  id        BigInt     @id @default(autoincrement())
+  userId    Int        @map("user_id")
+  bookId    Int        @map("book_id")
+  createdAt DateTime   @default(now()) @map("created_at") @db.DateTime(0)
+  user      User       @relation(fields: [userId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  book      StoryLists @relation(fields: [bookId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+
+  @@index([userId], map: "idx_read_logs_user_id")
+  @@index([bookId], map: "idx_read_logs_book_id")
+  @@index([createdAt], map: "idx_read_logs_created_at")
+  @@index([userId, bookId], map: "idx_read_logs_user_book")
+  @@map("read_logs")
 }
 
 model BookStoreItem {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { BookstoreModule } from './bookstore/bookstore.module';
 import { OrdersModule } from './orders/orders.module';
 import { ActivitiesModule } from './activities/activities.module';
 import { AdminModule } from './admin/admin.module';
+import { BooksModule } from './books/books.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { AdminModule } from './admin/admin.module';
     OrdersModule,
     ActivitiesModule,
     AdminModule,
+    BooksModule,
   ],
   providers: [PrismaService],
 })

--- a/src/books/books.controller.ts
+++ b/src/books/books.controller.ts
@@ -1,0 +1,165 @@
+import { Controller, Get, HttpCode, HttpStatus, Param, ParseIntPipe, Post, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+} from '@nestjs/swagger';
+import { AdminGuard } from '../auth/admin.guard';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { BooksService } from './books.service';
+import { BooksAnalyticsQueryDto } from './dto/books-analytics-query.dto';
+import { BooksAnalyticsResponseDto } from './dto/books-analytics-response.dto';
+import { ReadBookResponseDto } from './dto/read-book-response.dto';
+
+@ApiTags('Books')
+@Controller()
+export class BooksController {
+  constructor(private readonly booksService: BooksService) {}
+
+  @Post('books/:id/read')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '使用者觸發閱讀',
+    description: `
+      使用者每次點擊閱讀時呼叫此 API。
+
+      **資料一致性設計**：
+      - 使用 Database Transaction 同步寫入 read_logs 與更新書籍快取統計欄位
+      - 交易內會鎖定該書籍 row，避免高併發下 unique_readers 重複累加
+      - 每次閱讀都會新增一筆 read_logs 流水帳
+    `,
+  })
+  @ApiParam({
+    name: 'id',
+    description: '書籍 ID（StoryLists.id）',
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '成功記錄閱讀',
+    type: ReadBookResponseDto,
+    example: {
+      success: true,
+      readLogId: '123456789',
+      bookId: 1,
+      isFirstRead: true,
+      total_reads: 128,
+      unique_readers: 42,
+      readAt: '2026-05-27T10:30:00.000Z',
+    },
+  })
+  @ApiNotFoundResponse({
+    description: '書籍不存在',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: '書籍 (ID: 999999) 不存在',
+        error: 'Not Found',
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({
+    description: '未授權 - 憑證無效或未登入',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: '缺少 Authorization header',
+        error: 'Unauthorized',
+      },
+    },
+  })
+  recordRead(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: any,
+  ): Promise<ReadBookResponseDto> {
+    return this.booksService.recordRead(id, user.userId);
+  }
+
+  @Get('admin/books/analytics')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: '【後台】查看書籍閱讀統計清單',
+    description: `
+      管理員查看每本書的閱讀總次數與不重複閱讀人數。
+
+      **效能重點**：
+      - 直接讀取書籍表快取欄位 total_reads 與 unique_readers
+      - 不對 read_logs 做全表 COUNT，避免統計 API 隨流水帳資料量線性變慢
+      - 需要 roleLevel >= 9 的管理員權限
+    `,
+  })
+  @ApiQuery({
+    name: 'page',
+    description: '頁碼（可選，預設 1）',
+    type: Number,
+    example: 1,
+    required: false,
+  })
+  @ApiQuery({
+    name: 'limit',
+    description: '每頁筆數（可選，預設 20）',
+    type: Number,
+    example: 20,
+    required: false,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '成功取得書籍統計清單',
+    type: BooksAnalyticsResponseDto,
+    example: {
+      data: [
+        {
+          id: 1,
+          title: '小鎮失蹤手冊',
+          author: '夏佩爾&烏奴奴',
+          total_reads: 128,
+          unique_readers: 42,
+          createdAt: '2026-05-15T10:30:00.000Z',
+          updatedAt: '2026-05-27T10:30:00.000Z',
+        },
+      ],
+      pagination: {
+        total: 50,
+        page: 1,
+        limit: 20,
+        totalPages: 3,
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({
+    description: '未授權 - 憑證無效或未登入',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: '缺少 Authorization header',
+        error: 'Unauthorized',
+      },
+    },
+  })
+  @ApiForbiddenResponse({
+    description: '權限不足 - 需要 roleLevel >= 9',
+    schema: {
+      example: {
+        message: '只有管理員可存取此資源',
+        error: 'Forbidden',
+        statusCode: 403,
+      },
+    },
+  })
+  getAnalytics(
+    @Query() query: BooksAnalyticsQueryDto,
+  ): Promise<BooksAnalyticsResponseDto> {
+    return this.booksService.getAnalytics(query);
+  }
+}

--- a/src/books/books.module.ts
+++ b/src/books/books.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { BooksController } from './books.controller';
+import { BooksService } from './books.service';
+
+@Module({
+  controllers: [BooksController],
+  providers: [BooksService, PrismaService],
+})
+export class BooksModule {}

--- a/src/books/books.service.ts
+++ b/src/books/books.service.ts
@@ -1,0 +1,144 @@
+import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma.service';
+import { BooksAnalyticsQueryDto } from './dto/books-analytics-query.dto';
+import { BooksAnalyticsResponseDto } from './dto/books-analytics-response.dto';
+import { ReadBookResponseDto } from './dto/read-book-response.dto';
+
+@Injectable()
+export class BooksService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async recordRead(bookId: number, userId: number): Promise<ReadBookResponseDto> {
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const lockedBooks = await tx.$queryRaw<Array<{ id: number }>>`
+          SELECT id
+          FROM StoryLists
+          WHERE id = ${bookId}
+          FOR UPDATE
+        `;
+
+        if (lockedBooks.length === 0) {
+          throw new NotFoundException(`書籍 (ID: ${bookId}) 不存在`);
+        }
+
+        const existingRead = await tx.readLog.findFirst({
+          where: {
+            userId,
+            bookId,
+          },
+          select: {
+            id: true,
+          },
+        });
+        const isFirstRead = !existingRead;
+
+        const readLog = await tx.readLog.create({
+          data: {
+            userId,
+            bookId,
+          },
+        });
+
+        const updatedBook = await tx.storyLists.update({
+          where: {
+            id: bookId,
+          },
+          data: {
+            totalReads: {
+              increment: 1,
+            },
+            ...(isFirstRead
+              ? {
+                  uniqueReaders: {
+                    increment: 1,
+                  },
+                }
+              : {}),
+          },
+          select: {
+            id: true,
+            totalReads: true,
+            uniqueReaders: true,
+          },
+        });
+
+        return {
+          success: true,
+          readLogId: readLog.id.toString(),
+          bookId: updatedBook.id,
+          isFirstRead,
+          total_reads: updatedBook.totalReads,
+          unique_readers: updatedBook.uniqueReaders,
+          readAt: readLog.createdAt,
+        };
+      });
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+
+      throw new InternalServerErrorException({
+        success: false,
+        message: '記錄閱讀失敗',
+      });
+    }
+  }
+
+  async getAnalytics(query: BooksAnalyticsQueryDto): Promise<BooksAnalyticsResponseDto> {
+    try {
+      const page = query.page || 1;
+      const limit = query.limit || 20;
+      const skip = (page - 1) * limit;
+
+      const [data, total] = await Promise.all([
+        this.prisma.storyLists.findMany({
+          select: {
+            id: true,
+            main_menu_name: true,
+            stroy_name: true,
+            author: true,
+            totalReads: true,
+            uniqueReaders: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+          orderBy: {
+            totalReads: 'desc',
+          },
+          skip,
+          take: limit,
+        }),
+        this.prisma.storyLists.count(),
+      ]);
+
+      return {
+        data: data.map((book) => ({
+          id: book.id,
+          title: book.main_menu_name || book.stroy_name || 'Untitled',
+          author: book.author,
+          total_reads: book.totalReads,
+          unique_readers: book.uniqueReaders,
+          createdAt: book.createdAt,
+          updatedAt: book.updatedAt,
+        })),
+        pagination: {
+          total,
+          page,
+          limit,
+          totalPages: Math.ceil(total / limit),
+        },
+      };
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw new InternalServerErrorException({
+          success: false,
+          message: '資料庫查詢失敗',
+        });
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/books/dto/books-analytics-query.dto.ts
+++ b/src/books/dto/books-analytics-query.dto.ts
@@ -1,0 +1,16 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class BooksAnalyticsQueryDto {
+  @IsOptional()
+  @IsInt({ message: 'page 必須是整數' })
+  @Min(1, { message: 'page 必須大於等於 1' })
+  @Type(() => Number)
+  page?: number = 1;
+
+  @IsOptional()
+  @IsInt({ message: 'limit 必須是整數' })
+  @Min(1, { message: 'limit 必須大於等於 1' })
+  @Type(() => Number)
+  limit?: number = 20;
+}

--- a/src/books/dto/books-analytics-response.dto.ts
+++ b/src/books/dto/books-analytics-response.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BookAnalyticsItemDto {
+  @ApiProperty({ description: '書籍 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '書名', example: '小鎮失蹤手冊' })
+  title: string;
+
+  @ApiProperty({ description: '作者', example: '夏佩爾&烏奴奴', required: false })
+  author: string | null;
+
+  @ApiProperty({ description: '閱讀總次數', example: 128 })
+  total_reads: number;
+
+  @ApiProperty({ description: '不重複閱讀人數', example: 42 })
+  unique_readers: number;
+
+  @ApiProperty({ description: '建立時間', example: '2026-05-15T10:30:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ description: '更新時間', example: '2026-05-15T12:34:56.000Z' })
+  updatedAt: Date;
+}
+
+export class BooksAnalyticsPaginationDto {
+  @ApiProperty({ description: '總筆數', example: 50 })
+  total: number;
+
+  @ApiProperty({ description: '目前頁碼', example: 1 })
+  page: number;
+
+  @ApiProperty({ description: '每頁筆數', example: 20 })
+  limit: number;
+
+  @ApiProperty({ description: '總頁數', example: 3 })
+  totalPages: number;
+}
+
+export class BooksAnalyticsResponseDto {
+  @ApiProperty({ type: [BookAnalyticsItemDto], description: '書籍統計清單' })
+  data: BookAnalyticsItemDto[];
+
+  @ApiProperty({ type: BooksAnalyticsPaginationDto, description: '分頁資訊' })
+  pagination: BooksAnalyticsPaginationDto;
+}

--- a/src/books/dto/read-book-response.dto.ts
+++ b/src/books/dto/read-book-response.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ReadBookResponseDto {
+  @ApiProperty({ description: '請求是否成功', example: true })
+  success: boolean;
+
+  @ApiProperty({ description: '閱讀流水帳 ID', example: '123456789' })
+  readLogId: string;
+
+  @ApiProperty({ description: '書籍 ID', example: 1 })
+  bookId: number;
+
+  @ApiProperty({ description: '是否為該使用者首次閱讀此書', example: true })
+  isFirstRead: boolean;
+
+  @ApiProperty({ description: '更新後的閱讀總次數', example: 128 })
+  total_reads: number;
+
+  @ApiProperty({ description: '更新後的不重複閱讀人數', example: 42 })
+  unique_readers: number;
+
+  @ApiProperty({ description: '閱讀時間', example: '2026-05-27T10:30:00.000Z' })
+  readAt: Date;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Auth API')
     .setDescription('烏努努小說平台後端 API 文件')
-    .setVersion('1.9.13')
+    .setVersion('1.9.14')
     .addBearerAuth()
     .build();
 


### PR DESCRIPTION
- 新增 `BooksController` 和 `BooksService`，提供書籍閱讀紀錄的 API。
- 新增 `read_logs` 資料表以儲存每次閱讀的紀錄。
- 新增書籍統計 API，讓管理員查看書籍的閱讀總次數與不重複閱讀人數。
- 更新 `StoryLists` 模型以包含閱讀統計欄位。
- 實作資料庫交易以確保閱讀紀錄與統計更新的一致性。
- 更新 Swagger 文件以反映新的 API 端點與資料結構。
- 更新版本號至 1.9.14。