### PR TITLE
feat(iap): 新增 IAP 收據項目的 ID 欄位

### DIFF
--- a/src/iap/dto/admin-iap-receipts-response.dto.ts
+++ b/src/iap/dto/admin-iap-receipts-response.dto.ts
@@ -1,4 +1,5 @@
 export class AdminIapReceiptItemDto {
+  id: number; // iap_receipts.id
   receiptId: string; // transaction_id
   userId: number;
   username: string;

--- a/src/iap/iap-query.controller.ts
+++ b/src/iap/iap-query.controller.ts
@@ -72,6 +72,7 @@ export class IapQueryController {
     example: {
       items: [
         {
+          id: 1,
           receiptId: 'GPA.3218-2019-1234567890',
           userId: 12,
           username: 'John Doe',
@@ -88,6 +89,7 @@ export class IapQueryController {
           createdAt: '2026-02-27T10:30:00.000Z',
         },
         {
+          id: 2,
           receiptId: '17000123456789012',
           userId: 12,
           username: 'John Doe',

--- a/src/iap/iap-query.service.ts
+++ b/src/iap/iap-query.service.ts
@@ -214,6 +214,7 @@ export class IapQueryService {
         const bonus = r.pack_bonus !== null ? r.pack_bonus : 0;
 
         return {
+          id: r.id,
           receiptId: r.transaction_id,
           userId: r.user_id,
           username: userProfile?.name || '未知用戶',


### PR DESCRIPTION
- 在 `IapQueryService` 中的 `getReceipts` 方法中，新增了 `id` 欄位，對應到 `iap_receipts` 表的主鍵。
- 在 `IapQueryController` 的 API 回應範例中，新增了 `id` 欄位，以反映服務層的變更。
- 在 `AdminIapReceiptItemDto` 中新增了 `id` 欄位，以確保 DTO �結構與服務層一致。 這些變更將有助於前端更方便地識別和操作 IAP 收據項目，並且為未來可能的功能擴展提供基礎。